### PR TITLE
feat: 유효성 폼 요소 & 회원가입 계정 페이지 퍼블리싱

### DIFF
--- a/app/(auth)/(signup)/_layout.tsx
+++ b/app/(auth)/(signup)/_layout.tsx
@@ -1,28 +1,47 @@
-import { useSignupProgress } from '@/src/features/signup/hooks';
 import { cn } from '@/src/shared/libs/cn';
 import { platform } from '@/src/shared/libs/platform';
 import { PalePurpleGradient } from '@/src/shared/ui/gradient';
 import { ProgressBar } from '@/src/shared/ui/progress-bar';
-import { Stack } from 'expo-router';
+import { Stack, router } from 'expo-router';
 import { View } from 'react-native';
+import Signup from '@features/signup';
+import { useCallback, useRef } from 'react';
+import { useFocusEffect } from '@react-navigation/native';
+import { BackHandler } from 'react-native';
+
+const { useSignupProgress, SignupSteps } = Signup;
 
 export default function SignupLayout() {
-  const { progress } = useSignupProgress();
-  
+  const { progress, updateStep } = useSignupProgress();
+
+  const handleBackPress = useCallback(() => {
+    updateStep(SignupSteps.TERMS);
+    return true;
+  }, [updateStep]);
+
+  useFocusEffect(
+    useCallback(() => {
+      BackHandler.addEventListener('hardwareBackPress', handleBackPress);
+      return () => {
+        BackHandler.removeEventListener('hardwareBackPress', handleBackPress);
+      };
+    }, [handleBackPress])
+  );
+
   return (
     <View className="flex-1">
-        <PalePurpleGradient />
-        <View className={cn(
-          "px-5 pb-[30px] items-center bg-white",
-          platform({
-            ios: () => "pt-[80px]",
-            android: () => "pt-[80px]",
-            web: () => "pt-[30px]",
-          })
-        )}>
-          <ProgressBar progress={progress} />
-        </View>
-        <Stack
+      <PalePurpleGradient />
+      <View className={cn(
+        "px-5 pb-[30px] items-center bg-white",
+        platform({
+          ios: () => "pt-[80px]",
+          android: () => "pt-[80px]",
+          web: () => "pt-[30px]",
+        })
+      )}>
+        <ProgressBar progress={progress} />
+      </View>
+      <Stack
         screenOptions={{
           headerShown: false,
           contentStyle: {
@@ -32,8 +51,13 @@ export default function SignupLayout() {
         }}
       >
         <Stack.Screen name="index" options={{ headerShown: false }} />
-        <Stack.Screen name="email" options={{ headerShown: false }} />
-        <Stack.Screen name="password" options={{ headerShown: false }} />
+        <Stack.Screen 
+          name="account" 
+          options={{ 
+            headerShown: false,
+            headerBackVisible: false,
+          }}
+        />
         <Stack.Screen name="profile" options={{ headerShown: false }} />
       </Stack>
     </View>

--- a/app/(auth)/(signup)/account.tsx
+++ b/app/(auth)/(signup)/account.tsx
@@ -1,0 +1,89 @@
+import { View } from 'react-native';
+import { Text } from '@/src/shared/ui/text';
+import { PalePurpleGradient } from '@/src/shared/ui/gradient';
+import { Image } from 'expo-image';
+import { Button } from '@/src/shared/ui';
+import { router } from 'expo-router';
+import Signup from '@/src/features/signup';
+import { Form } from '@/src/widgets';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+
+const { SignupSteps, useChangePhase, schemas } = Signup;
+
+type Form = {
+  email: string;
+  password: string;
+  passwordConfirm: string;
+}
+
+
+export default function AccountScreen() {
+  const form = useForm<Form>({
+    resolver: zodResolver(schemas.account),
+    mode: 'onBlur',
+  });
+
+  const { handleSubmit, formState: { errors, isValid } } = form;
+
+  const isPasswordMatch = form.watch('password') === form.watch('passwordConfirm');
+
+  const onNext = handleSubmit((data) => {
+    router.push('/');
+  });
+
+  const nextable = (() => {
+    if (!isValid) return false;
+    if (!isPasswordMatch) return false;
+    return true;
+  })();
+
+  useChangePhase(SignupSteps.ACCOUNT);
+
+  return (
+    <View className="flex-1 flex flex-col">
+      <PalePurpleGradient />
+      <View className="px-5">
+        <Image  
+          source={require('@assets/images/profile.png')}
+          style={{ width: 128, height: 128 }}
+        />
+          <Text weight="semibold" size="20" textColor="black">
+          동의해 주셔서 감사합니다 :)
+          </Text>
+          <Text weight="semibold" size="20" textColor="black">
+          이제 몇 가지만 더 알려주세요
+          </Text>
+      </View>
+
+      <View className="px-8 flex flex-col gap-y-[40px] flex-1 mt-[30px]">
+        <Form.LabelInput 
+          name="email"
+          control={form.control}
+          label="이메일" 
+          placeholder="이메일 주소"
+        />
+        <Form.LabelInput 
+          name="password"
+          control={form.control}
+          label="비밀번호" 
+          placeholder="영문, 숫자, 특수문자 조합 8자리 이상"
+          isPassword 
+        />
+        <Form.LabelInput 
+          name="passwordConfirm"
+          control={form.control}
+          label="비밀번호 확인" 
+          placeholder="영문, 숫자, 특수문자 조합 8자리 이상"
+          isPassword 
+        />
+      </View>
+
+      <View className="px-5 mb-[58px] w-full">
+        <Button onPress={onNext} className="w-full" disabled={!nextable}>
+          동의하고 계속하기 
+        </Button>
+      </View>
+    </View>
+  );
+}

--- a/app/(auth)/(signup)/index.tsx
+++ b/app/(auth)/(signup)/index.tsx
@@ -7,15 +7,25 @@ import { CheckboxLabel } from '@/src/widgets';
 import { router } from 'expo-router';
 import { useState } from 'react';
 import { debounce } from '@/src/shared/libs/debounce';
+import Signup from '@/src/features/signup';
+
+const { useSignupProgress, SignupSteps, useChangePhase } = Signup;
 
 export default function TermsScreen() {
   const [agreements, setAgreements] = useState<Agreement[]>(AGREEMENTS);
-
+  const { updateStep } = useSignupProgress();
   const allAgreement = agreements.every(agreement => agreement.checked);
+  useChangePhase(SignupSteps.TERMS);
 
   const isNext = agreements
     .filter(agreement => agreement.required)
     .every(agreement => agreement.checked);
+
+  const onNext = () => {
+    if (!isNext) return;
+    updateStep(SignupSteps.ACCOUNT);
+    router.push('/(auth)/(signup)/account');
+  }
 
   const handleAgreement = debounce((id: string, value: boolean) => {
     setAgreements(prev => prev.map(agreement => agreement.id === id ? { ...agreement, checked: value } : agreement));
@@ -86,7 +96,7 @@ export default function TermsScreen() {
       </View>
 
       <View className="px-5 mb-[58px] w-full">
-        <Button onPress={() => router.push('/')} className="w-full" disabled={!isNext}>
+        <Button onPress={onNext} className="w-full" disabled={!isNext}>
           동의하고 계속하기 
         </Button>
       </View>

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "dependencies": {
         "@expo/vector-icons": "^14.0.2",
+        "@hookform/resolvers": "^5.0.1",
         "@react-native-async-storage/async-storage": "^2.1.2",
         "@react-navigation/bottom-tabs": "^7.2.0",
         "@react-navigation/elements": "^2.3.8",
@@ -36,6 +37,7 @@
         "nativewind": "^4.1.23",
         "react": "18.3.1",
         "react-dom": "18.3.1",
+        "react-hook-form": "^7.55.0",
         "react-native": "0.76.9",
         "react-native-gesture-handler": "~2.20.2",
         "react-native-progress": "^5.0.1",
@@ -48,6 +50,7 @@
         "tailwind-merge": "^3.2.0",
         "tailwindcss": "^3.4.17",
         "tw-merge": "^0.0.1-alpha.3",
+        "zod": "^3.24.2",
         "zustand": "^5.0.3"
       },
       "devDependencies": {
@@ -3126,6 +3129,18 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/@hookform/resolvers": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.0.1.tgz",
+      "integrity": "sha512-u/+Jp83luQNx9AdyW2fIPGY6Y7NG68eN2ZW8FOJYL+M0i4s49+refdJdOp/A9n9HFQtQs3HIDHQvX3ZET2o7YA==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.55.0"
+      }
+    },
     "node_modules/@isaacs/cliui": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
@@ -4348,6 +4363,12 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
       }
+    },
+    "node_modules/@standard-schema/utils": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
+      "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
+      "license": "MIT"
     },
     "node_modules/@svgr/babel-plugin-add-jsx-attribute": {
       "version": "8.0.0",
@@ -13003,6 +13024,22 @@
         "react-dom": "^16.6.0 || ^17.0.0 || ^18.0.0"
       }
     },
+    "node_modules/react-hook-form": {
+      "version": "7.55.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.55.0.tgz",
+      "integrity": "sha512-XRnjsH3GVMQz1moZTW53MxfoWN7aDpUg/GpVNc4A3eXRVNdGXfbzJ4vM4aLQ8g6XCUh1nIbx70aaNCl7kxnjog==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
@@ -16020,6 +16057,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.24.2",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
+      "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zustand": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@expo/vector-icons": "^14.0.2",
+    "@hookform/resolvers": "^5.0.1",
     "@react-native-async-storage/async-storage": "^2.1.2",
     "@react-navigation/bottom-tabs": "^7.2.0",
     "@react-navigation/elements": "^2.3.8",
@@ -30,6 +31,7 @@
     "expo-constants": "~17.0.8",
     "expo-font": "~13.0.4",
     "expo-haptics": "~14.0.1",
+    "expo-image": "~2.0.7",
     "expo-linear-gradient": "~14.0.2",
     "expo-linking": "~7.0.5",
     "expo-router": "~4.0.20",
@@ -42,6 +44,7 @@
     "nativewind": "^4.1.23",
     "react": "18.3.1",
     "react-dom": "18.3.1",
+    "react-hook-form": "^7.55.0",
     "react-native": "0.76.9",
     "react-native-gesture-handler": "~2.20.2",
     "react-native-progress": "^5.0.1",
@@ -54,8 +57,8 @@
     "tailwind-merge": "^3.2.0",
     "tailwindcss": "^3.4.17",
     "tw-merge": "^0.0.1-alpha.3",
-    "zustand": "^5.0.3",
-    "expo-image": "~2.0.7"
+    "zod": "^3.24.2",
+    "zustand": "^5.0.3"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/src/features/signup/hooks/index.tsx
+++ b/src/features/signup/hooks/index.tsx
@@ -1,1 +1,3 @@
-export { default as useSignupProgress } from './use-signup-progress';
+export { default as useSignupProgress, SignupSteps } from './use-signup-progress';
+export { default as useChangePhase } from './use-change-phase';
+

--- a/src/features/signup/hooks/use-change-phase.tsx
+++ b/src/features/signup/hooks/use-change-phase.tsx
@@ -1,0 +1,17 @@
+import { useFocusEffect } from "expo-router";
+import { useCallback } from "react";
+import { SignupSteps, useSignupProgress } from "../hooks";
+
+export default function useChangePhase(phase: SignupSteps) {
+  const { updateStep } = useSignupProgress();
+
+  const initialize = useCallback(() => {
+    updateStep(phase);
+  }, [updateStep]);
+
+  useFocusEffect(
+    useCallback(() => {
+      initialize();
+    }, [initialize])
+  );  
+}

--- a/src/features/signup/hooks/use-signup-progress.tsx
+++ b/src/features/signup/hooks/use-signup-progress.tsx
@@ -7,7 +7,7 @@ type StoreProps = {
   updateStep: (step: SignupSteps) => void;
 };
 
-enum SignupSteps {
+export enum SignupSteps {
   TERMS = 1,
   ACCOUNT = 2,
   PERSON = 3,

--- a/src/features/signup/index.tsx
+++ b/src/features/signup/index.tsx
@@ -1,9 +1,13 @@
 import { Logo, LoginForm } from "./ui";
 import * as hooks from "./hooks";
+import { accountSchema } from "./services/schema";
 
 const Signup = {
   Logo, 
   LoginForm,
+  schemas: {
+    account: accountSchema,
+  },
   ...hooks,
 };
 

--- a/src/features/signup/services/schema.ts
+++ b/src/features/signup/services/schema.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+const passwordRegex = /^(?=.*[a-zA-Z])(?=.*[0-9])(?=.*[!@#$%^&*_=+-]).{8,}$/;
+
+export const accountSchema = z.object({
+  email: z.string().email({ message: '올바른 이메일을 입력해주세요.' }),
+  password: z.string().regex(passwordRegex, { message: '영문, 숫자, 특수문자 조합 8자리 이상을 입력해주세요.' }),
+  passwordConfirm: z.string().regex(passwordRegex, { message: '영문, 숫자, 특수문자 조합 8자리 이상을 입력해주세요.' }),
+});

--- a/src/features/signup/ui/logo.tsx
+++ b/src/features/signup/ui/logo.tsx
@@ -6,14 +6,6 @@ import { Text } from "@/src/shared/ui";
 import { cn } from "@/src/shared/libs/cn";
 import { platform } from "@/src/shared/libs/platform";
 
-const styles = StyleSheet.create({
-  shadowText: {
-    textShadowColor: '#A9A9A9',
-    textShadowOffset: { width: 0, height: 1 },
-    textShadowRadius: 2,
-  },
-});
-
 export default function Logo() {
   return (
     <View className={cn(
@@ -34,7 +26,7 @@ export default function Logo() {
     </View>
     <View className="items-center pt-[8px] flex flex-col gap-y-[6px]">
       <Text className="text-[25px] font-semibold text-black">익숙한 하루에 설렘 하나,</Text>
-        <Text className="text-[15px] text-[#4F4F4F]" style={styles.shadowText}>SOMETIME에서</Text>
+        <Text className="text-[15px] text-[#4F4F4F]">SOMETIME에서</Text>
       </View>
     </View>
   );

--- a/src/shared/ui/input/index.tsx
+++ b/src/shared/ui/input/index.tsx
@@ -29,7 +29,7 @@ const input = cva(
   }
 );
 
-interface InputProps extends Omit<TextInputProps, 'style'>, VariantProps<typeof input> {
+export interface InputProps extends Omit<TextInputProps, 'style'>, VariantProps<typeof input> {
   className?: string;
   containerClassName?: string;
   isPassword?: boolean;

--- a/src/widgets/form/index.tsx
+++ b/src/widgets/form/index.tsx
@@ -1,0 +1,7 @@
+  import { FormInput } from "./input";
+import { FormLabelInput } from "./label-input";
+
+export const Form = {
+  Input: FormInput,
+  LabelInput: FormLabelInput,
+}

--- a/src/widgets/form/input.tsx
+++ b/src/widgets/form/input.tsx
@@ -1,0 +1,33 @@
+import { useController, Control } from 'react-hook-form';
+import { Input, type InputProps } from '@/src/shared/ui';
+
+interface FormInputProps extends Omit<InputProps, 'value' | 'onChangeText'> {
+  control: Control<any>;
+  name: string;
+  rules?: Record<string, any>;
+}
+
+export function FormInput({
+  control,
+  name,
+  rules,
+  ...props
+}: FormInputProps) {
+  const {
+    field: { value, onChange },
+    fieldState: { error }
+  } = useController({
+    name,
+    control,
+    rules
+  });
+
+  return (
+    <Input
+      value={value}
+      onChangeText={onChange}
+      status={error ? "error" : "default"}
+      {...props}
+    />
+  );
+}

--- a/src/widgets/form/label-input.tsx
+++ b/src/widgets/form/label-input.tsx
@@ -1,0 +1,35 @@
+import { useController, Control } from 'react-hook-form';
+import { LabelInput } from '@/src/widgets/label-input';
+import type { LabelInputProps } from '@/src/widgets/label-input';
+
+interface FormLabelInputProps extends Omit<LabelInputProps, 'value' | 'onChangeText' | 'error'> {
+  control: Control<any>;
+  name: string;
+  rules?: Record<string, any>;
+}
+
+export function FormLabelInput({
+  control,
+  name,
+  rules,
+  ...props
+}: FormLabelInputProps) {
+  const {
+    field: { value, onChange, onBlur },
+    fieldState: { error }
+  } = useController({
+    name,
+    control,
+    rules
+  });
+
+  return (
+    <LabelInput
+      value={value}
+      onChangeText={onChange}
+      error={error?.message}
+      onBlur={onBlur}
+      {...props}
+    />
+  );
+}

--- a/src/widgets/index.tsx
+++ b/src/widgets/index.tsx
@@ -1,1 +1,4 @@
 export * from './checkbox-label';
+export * from './label-input';
+export * from './form';
+

--- a/src/widgets/label-input/index.tsx
+++ b/src/widgets/label-input/index.tsx
@@ -1,0 +1,61 @@
+import { View } from 'react-native';
+import { Input, Text } from '@/src/shared/ui';
+import type { InputProps } from '@/src/shared/ui';
+import { cn } from '@shared/libs/cn';
+
+export interface LabelInputProps extends InputProps {
+  label: string;
+  required?: boolean;
+  description?: string;
+  placeholder?: string;
+  onBlur?: () => void;
+  error?: string;
+  wrapperClassName?: string;
+}
+
+export function LabelInput({
+  label,
+  required = false,
+  description,
+  error,
+  wrapperClassName,
+  containerClassName,
+  placeholder,
+  onBlur,
+  ...props
+}: LabelInputProps) {
+  return (
+    <View className={cn("space-y-2", wrapperClassName)}>
+      <View className="flex-row items-center gap-x-1">
+        <Text size="md" weight="semibold" textColor="purple">
+          {label}
+        </Text>
+        {required && (
+          <Text size="sm" textColor="purple">
+            *
+          </Text>
+        )}
+      </View>
+      
+      {description && (
+        <Text size="sm" textColor="black" className="mb-1">
+          {description}
+        </Text>
+      )}
+
+      <Input
+        containerClassName={cn("mb-1", containerClassName)}
+        placeholder={placeholder}
+        status={error ? "error" : "default"}
+        onBlur={onBlur}
+        {...props}
+      />
+
+      {error && (
+        <Text size="sm" className="text-red-500">
+          {error}
+        </Text>
+      )}
+    </View>
+  );
+}


### PR DESCRIPTION
# PR 개요
이 PR에서는 회원가입 기능과 관련된 여러 컴포넌트와 기능을 개선하고 추가했습니다. 주요 변경 사항은 다음과 같습니다:

### 주요 변경 사항
헤더 및 레이아웃 수정:
TermsScreen과 AccountScreen 컴포넌트에 헤더와 레이아웃을 추가하여 사용자 인터페이스를 개선했습니다.
FormProvider 사용:
AccountScreen에서 FormProvider를 사용하여 react-hook-form의 컨텍스트를 통해 폼 상태를 관리하도록 변경했습니다. 이를 통해 폼 컴포넌트 간에 상태를 쉽게 공유할 수 있습니다.
스키마 추가:
src/features/signup/index.tsx에 accountSchema를 추가하여 회원가입 시 입력된 데이터의 유효성을 검사할 수 있도록 했습니다.
기타 변경 사항
Signup 객체에 schemas 속성을 추가하여 스키마를 관리할 수 있도록 구조를 개선했습니다.
hooks를 Signup 객체에 포함시켜 관련 훅을 쉽게 사용할 수 있도록 했습니다.

![image](https://github.com/user-attachments/assets/27bf1da0-e067-4525-a095-2c98f07857ba)
