### PR TITLE
feat: `Select`, `fileUtils` 작성 / 대학 상세정보 퍼블리싱

### DIFF
--- a/app/(auth)/(signup)/_layout.tsx
+++ b/app/(auth)/(signup)/_layout.tsx
@@ -2,11 +2,11 @@ import { cn } from '@/src/shared/libs/cn';
 import { platform } from '@/src/shared/libs/platform';
 import { PalePurpleGradient } from '@/src/shared/ui/gradient';
 import { ProgressBar } from '@/src/shared/ui/progress-bar';
-import { Stack, router } from 'expo-router';
-import { View } from 'react-native';
 import Signup from '@features/signup';
-import { useCallback, useRef } from 'react';
 import { useFocusEffect } from '@react-navigation/native';
+import { Stack, router } from 'expo-router';
+import { useCallback, useRef } from 'react';
+import { View } from 'react-native';
 import { BackHandler } from 'react-native';
 
 const { useSignupProgress, SignupSteps } = Signup;
@@ -61,6 +61,7 @@ export default function SignupLayout() {
         <Stack.Screen name="profile" options={{ headerShown: false }} />
         <Stack.Screen name="profile-image" options={{ headerShown: false }} />
         <Stack.Screen name="university" options={{ headerShown: false }} />
+        <Stack.Screen name="university-details" options={{ headerShown: false }} />
       </Stack>
     </View>
   );

--- a/app/(auth)/(signup)/account.tsx
+++ b/app/(auth)/(signup)/account.tsx
@@ -13,7 +13,7 @@ import { platform } from '@/src/shared/libs/platform';
 
 const { SignupSteps, useChangePhase, schemas, useSignupProgress } = Signup;
 
-type Form = {
+type FormState = {
   email: string;
   password: string;
   passwordConfirm: string;
@@ -22,7 +22,7 @@ type Form = {
 export default function AccountScreen() {
   const { updateForm, form: { email, password } } = useSignupProgress();
 
-  const form = useForm<Form>({
+  const form = useForm<FormState>({
     resolver: zodResolver(schemas.account),
     mode: 'onBlur',
     defaultValues: {

--- a/app/(auth)/(signup)/profile.tsx
+++ b/app/(auth)/(signup)/profile.tsx
@@ -1,24 +1,24 @@
-import { View } from 'react-native';
-import { Text } from '@/src/shared/ui/text';
-import { PalePurpleGradient } from '@/src/shared/ui/gradient';
-import { Image } from 'expo-image';
-import { Button, Label } from '@/src/shared/ui';
-import { router } from 'expo-router';
 import Signup from '@/src/features/signup';
-import { Form } from '@/src/widgets';
-import { Controller, useForm } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
 import { cn } from '@/src/shared/libs/cn';
 import { platform } from '@/src/shared/libs/platform';
-import { Selector } from '@/src/widgets/selector';
+import { Button, Label } from '@/src/shared/ui';
+import { PalePurpleGradient } from '@/src/shared/ui/gradient';
+import { Text } from '@/src/shared/ui/text';
+import { Form } from '@/src/widgets';
 import { MbtiSelector } from '@/src/widgets/mbti-selector';
+import { Selector } from '@/src/widgets/selector';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { Image } from 'expo-image';
+import { router } from 'expo-router';
+import { Controller, useForm } from 'react-hook-form';
+import { View } from 'react-native';
 import { z } from 'zod';
 
 const { SignupSteps, useChangePhase, schemas, useSignupProgress } = Signup;
 
 type Gender = 'male' | 'female';
 
-type Form = {
+type FormState = {
   name: string;
   birthday: string;
   gender: Gender;
@@ -38,7 +38,7 @@ const schema = z.object({
 export default function ProfilePage() {
   const { updateForm, form: userForm } = useSignupProgress();
 
-  const form = useForm<Form>({
+  const form = useForm<FormState>({
     resolver: zodResolver(schema),
     mode: 'onBlur',
   });

--- a/app/(auth)/(signup)/university-details.tsx
+++ b/app/(auth)/(signup)/university-details.tsx
@@ -1,0 +1,177 @@
+import Signup from '@/src/features/signup';
+import { cn } from '@/src/shared/libs/cn';
+import { platform } from '@/src/shared/libs/platform';
+import { Button, Label } from '@/src/shared/ui';
+import { PalePurpleGradient } from '@/src/shared/ui/gradient';
+import { Text } from '@/src/shared/ui/text';
+import { Form } from '@/src/widgets';
+import { Image } from 'expo-image';
+import { router, useGlobalSearchParams } from 'expo-router';
+import { useForm } from 'react-hook-form';  
+import { zodResolver } from '@hookform/resolvers/zod';
+import { View } from 'react-native';
+import { z } from 'zod';
+
+const { SignupSteps, useChangePhase, useSignupProgress, queries } = Signup;
+const { useDepartmentQuery } = queries;
+
+type FormProps = {
+  departmentName: string;
+  grade: string;
+  studentNumber: string;
+  instagramId: string;
+}
+
+const gradeOptions = Array.from({ length: 5 }, (_, i) => ({
+  label: `${i + 1}학년`,
+  value: `${i + 1}학년`,
+}));
+
+const studentNumberOptions = ['25학번', '24학번', '23학번', '22학번', '21학번', '20학번', '19학번', '18학번', '17학번'];
+
+const schema = z.object({
+  departmentName: z.string().min(1),
+  grade: z.string().min(1),
+  studentNumber: z.string().min(1),
+  instagramId: z.string({ required_error: '인스타그램 아이디를 입력해주세요.' })
+  .min(5, {
+    message: '인스타그램 아이디를 입력해주세요.',
+  })
+  .max(30, {
+    message: '인스타그램 아이디는 최대 30자입니다.',
+  })
+});
+
+export default function UniversityDetailsPage() {
+  const { updateForm, form: userForm } = useSignupProgress();
+  const { universityName } = useGlobalSearchParams<{ universityName: string }>();
+  const { data: departments = [] } = useDepartmentQuery(universityName);
+  const form = useForm<FormProps>({
+    resolver: zodResolver(schema),
+    mode: 'onBlur',
+    defaultValues: {
+      departmentName: userForm.departmentName,
+      grade: userForm.grade,
+      studentNumber: userForm.studentNumber,
+      instagramId: userForm.instagramId,
+    },
+  });
+  
+  const { handleSubmit, formState: { isValid } } = form;
+
+  const onNext = handleSubmit((data) => {
+    updateForm({
+      ...userForm,
+      ...data,
+    });
+    router.push('/(auth)/(signup)/profile-image');
+  });
+
+  const nextable = (() => {
+    if (!isValid) return false;
+    return true;
+  })();
+
+  const nextButtonMessage = (() => {
+    if (!nextable) {
+      return '조금만 더 알려주세요';
+    }
+    return '다음으로';
+  })();
+
+  useChangePhase(SignupSteps.UNIVERSITY);
+
+  return (
+    <View className="flex-1 flex flex-col">
+      <PalePurpleGradient />
+      <View className="px-5">
+        <Image  
+          source={require('@assets/images/details.png')}
+          style={{ width: 81, height: 81 }}
+          className="mb-4"
+        />
+          <Text weight="semibold" size="20" textColor="black">
+          이제 몇 가지만
+          </Text>
+          <Text weight="semibold" size="20" textColor="black">
+          더 입력해 주시면 끝이에요!
+          </Text>
+      </View>
+
+      <View className="px-5 flex flex-col gap-y-[14px] mt-[20px] flex-1">
+        <View className="w-full">
+          <Label label="학과" size="sm" />
+          <Form.Select
+            size="sm"
+            name="departmentName"
+            control={form.control}
+            options={departments.map((department) => ({ label: department, value: department }))}
+            placeholder="학과를 선택하세요."
+          />
+        </View>
+    
+        <View className="w-full flex flex-row gap-x-[14px]">
+          <View className="flex-1 flex flex-row gap-x-[4px]">
+            <Form.Select
+              name="studentNumber"
+              control={form.control}
+              options={studentNumberOptions.map((option) => ({ label: option, value: option }))}
+              placeholder="학번 선택"
+              size="sm"
+              className="flex-1"
+            />
+            <Label label="학번" size="sm" />
+          </View>
+
+          <View className="flex-1 flex flex-row gap-x-[4px]">
+            <Form.Select
+              name="grade"
+              control={form.control}
+              options={gradeOptions}
+              placeholder="학년 선택"
+              size="sm"
+              className="flex-1"
+            />
+            <Label label="학년" size="sm" />
+          </View>
+
+        </View>
+
+        
+        <View className="w-full flex flex-col">
+          <Form.LabelInput
+            name="instagramId"
+            size="sm"
+            control={form.control}
+            label="인스타그램 아이디"
+            placeholder="인스타그램 아이디를 입력"
+          />
+                  <View className="w-full flex flex-col gap-y-0"> 
+          <Text size="sm" textColor="pale-purple">
+          사진을 업로드하고 계정을 공개로 설정하면, 매칭 확률이 높아져요.
+        </Text>
+        <Text size="sm" textColor="pale-purple">
+            매칭된 상대와 더 자연스러운 대화를 나눠보세요!
+          </Text>
+        </View>
+        </View>
+      </View>
+
+      <View className={cn(
+        platform({
+          web: () => "px-5 mb-[14px] w-full flex flex-row gap-x-[15px]",
+          android: () => "px-5 mb-[58px] w-full flex flex-row gap-x-[15px]",
+          ios: () => "px-5 mb-[58px] w-full flex flex-row gap-x-[15px]",
+          default: () => ""
+        })
+      )}>
+        <Button variant="secondary" onPress={() => router.push('/(auth)/(signup)/university')} className="flex-[0.3]">
+            뒤로
+        </Button>
+        <Button onPress={onNext} className="flex-[0.7]" disabled={!nextable}>
+          {nextButtonMessage}
+        </Button>
+      </View>
+    </View>
+  );
+}

--- a/app/(auth)/(signup)/university.tsx
+++ b/app/(auth)/(signup)/university.tsx
@@ -6,7 +6,7 @@ import { PalePurpleGradient } from '@/src/shared/ui/gradient';
 import { Text } from '@/src/shared/ui/text';
 import { ChipSelector, LabelInput } from '@/src/widgets';
 import { Image } from 'expo-image';
-import { router } from 'expo-router';
+import { router, useGlobalSearchParams } from 'expo-router';
 import { useState } from 'react';
 import { View } from 'react-native';
 
@@ -17,8 +17,11 @@ const { useUnivQuery } = queries;
 export default function UniversityPage() {
   const { updateForm, form: userForm } = useSignupProgress();
   const { data: univs = [], isLoading } = useUnivQuery();
-  const [selectedUniv, setSelectedUniv] = useState<string>();
+  const params = useGlobalSearchParams();
+  console.log(params);
+  const [selectedUniv, setSelectedUniv] = useState<string | undefined>(userForm.universityName);
   const filteredUnivs = univs.filter((univ) => univ.startsWith(selectedUniv || ''));
+  useChangePhase(SignupSteps.UNIVERSITY);
 
   const onNext = () => {
     if (!selectedUniv) {
@@ -26,8 +29,9 @@ export default function UniversityPage() {
     }
     updateForm({
       ...userForm,
+      universityName: selectedUniv,
     });
-    router.push('/(auth)/(signup)/profile-image');
+    router.push(`/(auth)/(signup)/university-details?universityName=${selectedUniv}`);
   };
 
   const nextable = (() => {
@@ -44,7 +48,6 @@ export default function UniversityPage() {
     return '다음으로';
   })();
 
-  useChangePhase(SignupSteps.UNIVERSITY);
 
   return (
     <View className="flex-1 flex flex-col">

--- a/src/features/signup/apis/index.tsx
+++ b/src/features/signup/apis/index.tsx
@@ -4,12 +4,18 @@ export const getUnivs = async (): Promise<string[]> => {
   return axiosClient.get('/universities');
 };
 
+export const getDepartments = async (univ: string): Promise<string[]> => {
+  return axiosClient.get(`/universities/departments?university=${univ}`);
+};
+
 type Service = {
   getUnivs: () => Promise<string[]>;
+  getDepartments: (univ: string) => Promise<string[]>;
 }
 
 const apis: Service = {
   getUnivs,
+  getDepartments,
 };
 
 export default apis;

--- a/src/features/signup/hooks/use-signup-progress.tsx
+++ b/src/features/signup/hooks/use-signup-progress.tsx
@@ -6,8 +6,13 @@ type SignupForm = {
   name: string;
   birthday: string;
   gender: 'female' | 'male';
+  universityName: string;
   mbti: string;
   profileImages: string[];
+  departmentName: string;
+  grade: string;
+  studentNumber: string;
+  instagramId: string;
 }
 
 type StoreProps = {

--- a/src/features/signup/queries/index.tsx
+++ b/src/features/signup/queries/index.tsx
@@ -1,1 +1,2 @@
 export { useUnivQuery } from "./use-university";
+export { useDepartmentQuery } from "./use-departments";

--- a/src/features/signup/queries/use-departments.tsx
+++ b/src/features/signup/queries/use-departments.tsx
@@ -1,0 +1,11 @@
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { getDepartments } from "../apis";
+
+export const useDepartmentQuery = (univ?: string) =>
+  useSuspenseQuery({
+    queryKey: ['departments', univ],
+    queryFn: () => {
+      if (!univ) return [] as string[];
+      return getDepartments(univ)
+    },
+  });

--- a/src/shared/libs/file.ts
+++ b/src/shared/libs/file.ts
@@ -1,0 +1,24 @@
+function dataURLtoBlob(dataURL: string) {
+  const parts = dataURL.split(';base64,');
+  const contentType = parts[0].split(':')[1];
+  const raw = window.atob(parts[1]);
+  const rawLength = raw.length;
+  const uInt8Array = new Uint8Array(rawLength);
+  
+  for (let i = 0; i < rawLength; ++i) {
+    uInt8Array[i] = raw.charCodeAt(i);
+  }
+  
+  return new Blob([uInt8Array], { type: contentType });
+}
+
+function createFileFromBlob(blob: Blob, fileName: string) {
+  return new File([blob], fileName, { type: blob.type });
+}
+
+const fileUtils = {
+  dataURLtoBlob,
+  toFile: createFileFromBlob,
+}
+
+export default fileUtils;

--- a/src/shared/libs/index.ts
+++ b/src/shared/libs/index.ts
@@ -3,4 +3,4 @@ export { platform } from './platform';
 export { debounce } from './debounce';
 export { cn } from './cn';
 export { sleep } from './sleep';
-
+export { default as fileUtils } from './file';

--- a/src/shared/ui/index.tsx
+++ b/src/shared/ui/index.tsx
@@ -8,3 +8,4 @@ export * from './divider';
 export * from './label';
 export * from './image-selector';
 export * from './lottie';
+export * from './select';

--- a/src/shared/ui/select/index.tsx
+++ b/src/shared/ui/select/index.tsx
@@ -1,0 +1,118 @@
+import { cn } from '@/src/shared/libs/cn';
+import { type VariantProps, cva } from 'class-variance-authority';
+import { useState } from 'react';
+import { Modal, TouchableOpacity, View } from 'react-native';
+import { Text } from '../text';
+
+const select = cva(
+  'w-full flex flex-col justify-center bg-transparent border-b border-[#E7E9EC]', 
+  {
+    variants: {
+      size: {
+        sm: 'h-10 text-sm',
+        md: 'h-12 text-md',
+        lg: 'h-14 text-lg',
+      },
+      status: {
+        default: 'border-lightPurple',
+        error: 'border-rose-400',
+        success: 'border-green-500',
+      },
+      isDisabled: {
+        true: 'opacity-50 bg-gray-100',
+      },
+    },
+    defaultVariants: {
+      size: 'md',
+      status: 'default',
+    },
+  }
+);
+
+interface Option {
+  label: string;
+  value: string;
+}
+
+export interface SelectProps extends VariantProps<typeof select> {
+  value?: string;
+  onChange?: (value: string) => void;
+  options: Option[];
+  placeholder?: string;
+  className?: string;
+  width?: number;
+}
+
+export function Select({
+  value,
+  onChange,
+  options,
+  size,
+  status,
+  isDisabled,
+  placeholder = '선택해주세요',
+  className,
+  width,
+}: SelectProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const selectedOption = options.find(option => option.value === value);
+
+  return (
+    <View className={cn(className)} style={width ? { width } : undefined}>
+      <TouchableOpacity 
+        onPress={() => !isDisabled && setIsOpen(!isOpen)}
+        activeOpacity={0.8}
+      >
+        <View className={select({ size, status, isDisabled })}>
+          <Text 
+            size={size} 
+            textColor={value ? 'black' : 'pale-purple'}
+            className="py-2"
+          >
+            {selectedOption?.label || placeholder}
+          </Text>
+        </View>
+      </TouchableOpacity>
+
+      <Modal
+        visible={isOpen}
+        transparent
+        animationType="fade"
+        onRequestClose={() => setIsOpen(false)}
+      >
+        <View className="flex-1 bg-black/30 justify-center items-center">
+          <View 
+            className="bg-white border border-lightPurple rounded-lg max-h-[200px] overflow-scroll"
+            style={{ 
+              width: 300,
+              maxWidth: '90%',
+              position: 'absolute',
+              top: 150,
+            }}
+          >
+            {options.map((option) => (
+              <TouchableOpacity
+                key={option.value}
+                onPress={() => {
+                  onChange?.(option.value);
+                  setIsOpen(false);
+                }}
+                className={cn(
+                  "py-3 px-4",
+                  value === option.value && "bg-lightPurple"
+                )}
+              >
+                <Text
+                  size={size}
+                  textColor={value === option.value ? 'purple' : 'black'}
+                >
+                  {option.label}
+                </Text>
+              </TouchableOpacity>
+            ))}
+          </View>
+        </View>
+      </Modal>
+    </View>
+  );
+}

--- a/src/widgets/form/index.tsx
+++ b/src/widgets/form/index.tsx
@@ -1,9 +1,11 @@
+import { FormImageSelector } from "./image-selector";
 import { FormInput } from "./input";
 import { FormLabelInput } from "./label-input";
-import { FormImageSelector } from "./image-selector";
+import { FormSelect } from "./select";
 
 export const Form = {
   Input: FormInput,
   LabelInput: FormLabelInput,
   ImageSelector: FormImageSelector,
+  Select: FormSelect,
 }

--- a/src/widgets/form/label-input.tsx
+++ b/src/widgets/form/label-input.tsx
@@ -3,8 +3,10 @@ import { LabelInput } from '@/src/widgets/label-input';
 import type { LabelInputProps } from '@/src/widgets/label-input';
 
 interface FormLabelInputProps extends Omit<LabelInputProps, 'value' | 'onChangeText' | 'error'> {
+  // biome-ignore lint/suspicious/noExplicitAny: <explanation>
   control: Control<any>;
   name: string;
+  // biome-ignore lint/suspicious/noExplicitAny: <explanation>
   rules?: Record<string, any>;
 }
 

--- a/src/widgets/form/select.tsx
+++ b/src/widgets/form/select.tsx
@@ -1,0 +1,53 @@
+import { Select as BaseSelect } from '@/src/shared/ui';
+import type { SelectProps } from '@/src/shared/ui/select';
+import {
+	type FieldValues,
+	type UseControllerProps,
+	useController
+} from 'react-hook-form';
+
+interface Option {
+	label: string;
+	value: string;
+}
+
+interface FormSelectProps<T extends FieldValues>
+	extends UseControllerProps<T>,
+		Omit<SelectProps, 'status'> {
+	options: Option[];
+	placeholder?: string;
+	className?: string;
+}
+
+export function FormSelect<T extends FieldValues>({
+	name,
+	control,
+	rules,
+	options,
+	size,
+	isDisabled,
+	placeholder,
+	className,
+}: FormSelectProps<T>) {
+	const {
+		field: { value, onChange },
+		fieldState: { error },
+	} = useController<T>({
+		name,
+		control,
+		rules,
+	});
+
+	return (
+		<BaseSelect
+			value={value}
+			onChange={onChange}
+			options={options}
+			size={size}
+			status={error ? 'error' : 'default'}
+			isDisabled={isDisabled}
+			placeholder={placeholder}
+			className={className}
+		/>
+	);
+}

--- a/src/widgets/label-input/index.tsx
+++ b/src/widgets/label-input/index.tsx
@@ -4,7 +4,7 @@ import type { InputProps } from '@/src/shared/ui';
 import { cn } from '@shared/libs/cn';
 import { cva, type VariantProps } from 'class-variance-authority';
 
-const labelInput = cva('space-y-2', {
+const labelInput = cva('flex flex-col', {
   variants: {
     size: {
       sm: 'gap-y-0',


### PR DESCRIPTION

#작업 내용
- `Selector` 컴포넌트 추가. 옵션 선택이 필요한 UI 가 있다면 활용하면 되겠습니다.
- `fileUtils` 추가. 파일 객체를 string -> blob -> file 순으로 자유자재로 변환 가능

# 페이지
![image](https://github.com/user-attachments/assets/33929161-535e-4f9c-9ea4-c2810ddb07f3)

# `Select`

![image](https://github.com/user-attachments/assets/b849fec3-8d9b-4df2-ae18-b7ce768cb36c)
