### PR TITLE
fix: 이상형 정보 입력 모달이 안나오는 버그 수정

### DIFF
--- a/src/features/home/hooks/index.tsx
+++ b/src/features/home/hooks/index.tsx
@@ -20,15 +20,18 @@ export const useRedirectPreferences = () => {
   const { showModal } = useModal();
 
   const checkShowAgain = useCallback(() => {
-    if (loading || !latest) return false;
-    const { isLater, latestDate } = latest;
-    if (!isLater && !isPreferenceFill) {
+    if (loading) return false;
+    if (!latest && isPreferenceFill) {
+      return true;
+    }
+
+    if (!latest?.isLater && !isPreferenceFill) {
       return true;
     }
     const now = dayUtils.create();
-    const diff = now.diff(latestDate, 'day');
+    const diff = now.diff(latest?.latestDate, 'day');
     return diff > 1;
-  }, [latest, isPreferenceFill]);
+  }, [latest, isPreferenceFill, loading]);
 
   const confirm = useCallback(() =>
     setValue({


### PR DESCRIPTION
이상형 정보 모달이 안나오는 오류를 수정했습니다.

다음에 이상형을 입력한다는 액션을 수행시 1일을 계산하여 시간 초과시 다시 렌더링됩니다.

렌더링 시점 - 홈화면 진입