### PR TITLE
feat: 개인정보 보호 약관 컴포넌트 추가

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -1,19 +1,32 @@
 name: Claude Assistant
 on:
   issue_comment:
-    types: [created]
+    types: [ created ]
   pull_request_review_comment:
-    types: [created, edited]
+    types: [ created, edited ]
   issues:
-    types: [opened, assigned, labeled]
+    types: [ opened, assigned, labeled ]
   pull_request_review:
-    types: [submitted]
+    types: [ submitted ]
 
 jobs:
   claude-response:
     runs-on: ubuntu-latest
+    permissions: # 추가: 필요한 권한 설정
+      contents: read
+      pull-requests: write
+      issues: write
     steps:
-      - uses: anthropics/claude-code-action@beta
+      # 필수 추가: Repository 체크아웃
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          # PR 컨텍스트에서 올바른 브랜치 체크아웃
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 0  # 전체 히스토리 가져오기 (필요시)
+
+      - name: Run Claude Code Action
+        uses: anthropics/claude-code-action@beta
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/src/features/auth/ui/index.tsx
+++ b/src/features/auth/ui/index.tsx
@@ -1,0 +1,1 @@
+export {PrivacyNotice} from './privacy-notice';

--- a/src/features/auth/ui/privacy-notice.tsx
+++ b/src/features/auth/ui/privacy-notice.tsx
@@ -1,0 +1,57 @@
+import {StyleSheet, View, TouchableOpacity, Linking} from 'react-native';
+import {Text} from '@ui/text';
+import colors from '@constants/colors';
+
+const PRIVACY_LINK = 'https://ruby-composer-6d2.notion.site/1cd1bbec5ba180a3a4bbdf9301683145';
+const SERVICE_LINK = 'https://ruby-composer-6d2.notion.site/1cd1bbec5ba1805dbafbc9426a0aaa80';
+const ENTERPIRSE_LINK = 'http://www.ftc.go.kr/bizCommPop.do?wrkr_no=4980502914';
+
+export const PrivacyNotice = () => (
+    <View className="flex flex-col w-full items-center">
+      <Text textColor="gray" className="text-[12px]">
+        회원가입 및 로그인 버튼을 누르면
+      </Text>
+
+      <View className="flex flex-row">
+        <TouchableOpacity onPress={() => Linking.openURL(PRIVACY_LINK)}>
+          <Text
+              style={{
+                ...styles.link,
+                marginRight: 2,
+              }}
+          >
+            개인정보 보호 약관,
+          </Text>
+        </TouchableOpacity>
+
+        <TouchableOpacity onPress={() => Linking.openURL(SERVICE_LINK)}>
+          <Text style={{...styles.link}}>서비스 이용약관</Text>
+        </TouchableOpacity>
+
+        <Text textColor="gray" className="text-[12px]">
+          에 동의하게 됩니다.
+        </Text>
+      </View>
+
+      <TouchableOpacity onPress={() => Linking.openURL(ENTERPIRSE_LINK)}>
+        <Text
+            style={{
+              ...styles.link,
+              marginTop: 10,
+              color: colors.gray,
+            }}
+        >
+          스마트 뉴비 사업자 정보 {'>'}
+        </Text>
+      </TouchableOpacity>
+    </View>
+);
+
+const styles = StyleSheet.create({
+  link: {
+    textDecorationLine: 'underline',
+    fontSize: 12,
+    color: colors['gray-600'],
+    fontWeight: '600',
+  },
+});


### PR DESCRIPTION
## 개요
회원가입 및 로그인 화면에서 사용할 개인정보 보호 약관 동의 컴포넌트를 추가했습니다.

## 구현 내용
- `PrivacyNotice` 컴포넌트 생성
- 개인정보 보호 약관, 서비스 이용약관, 사업자 정보 링크 제공
- 각 링크 클릭 시 외부 브라우저에서 열림

## 컴포넌트 사용 방법
```tsx
import {PrivacyNotice} from '@features/auth/ui';

// 로그인/회원가입 화면에서 사용
<PrivacyNotice />
```

## 화면 구성
![image](https://github.com/user-attachments/assets/1d1ee893-218a-4a43-9e6c-05fd87105bc0)

- "회원가입 및 로그인 버튼을 누르면" 안내 문구
- 개인정보 보호 약관과 서비스 이용약관 링크 (클릭 가능)
- "에 동의하게 됩니다." 안내 문구  
- 스마트 뉴비 사업자 정보 링크

## 링크 정보
- 개인정보 보호 약관: Notion 페이지
- 서비스 이용약관: Notion 페이지
- 사업자 정보: 공정거래위원회 사업자 정보 페이지

@yujaeyoon 리뷰 부탁드립니다.