### PR TITLE
feat: 중복 휴대폰 가입자 차단 api 연결

### DIFF
--- a/app/auth/signup/profile-image.tsx
+++ b/app/auth/signup/profile-image.tsx
@@ -56,6 +56,22 @@ export default function ProfilePage() {
 
     await tryCatch(
       async () => {
+        if (!signupForm.phone) {
+          showErrorModal('휴대폰 번호가 없습니다', 'announcement');
+          trackSignupEvent('signup_error', 'missing_phone');
+          router.push('/auth/login');
+          return;
+        }
+
+        const { exists } = await apis.checkPhoneNumberExists(signupForm.phone);
+
+        if (exists) {
+          showErrorModal('이미 가입된 사용자입니다', 'announcement');
+          trackSignupEvent('signup_error', 'phone_already_exists');
+          router.push('/auth/login');
+          return;
+        }
+
         await apis.signup(signupForm as SignupForm);
         trackSignupEvent('signup_complete');
         router.push('/auth/signup/done');

--- a/src/features/signup/apis/index.tsx
+++ b/src/features/signup/apis/index.tsx
@@ -31,6 +31,9 @@ const createFileObject = (imageUri: string, fileName: string) =>
     } as any)
   });
 
+export const checkPhoneNumberExists = (phoneNumber: string): Promise<{ exists: boolean }> =>
+  axiosClient.post('/auth/check/phone-number', { phoneNumber });
+
 export const signup = (form: SignupForm): Promise<void> => {
   const formData = new FormData();
   formData.append('phoneNumber', form.phone);
@@ -61,6 +64,7 @@ const authenticateSmsCode = (smsCode: AuthorizeSmsCode): Promise<void> =>
 type Service = {
   getUnivs: () => Promise<string[]>;
   getDepartments: (univ: string) => Promise<string[]>;
+  checkPhoneNumberExists: (phoneNumber: string) => Promise<{ exists: boolean }>;
   signup: (form: SignupForm) => Promise<void>;
   sendVerificationCode: (phoneNumber: string) => Promise<{ uniqueKey: string }>;
   authenticateSmsCode: (smsCode: AuthorizeSmsCode) => Promise<void>;
@@ -73,6 +77,7 @@ const sendVerificationCode = (phoneNumber: string): Promise<{ uniqueKey: string 
 const apis: Service = {
   getUnivs,
   getDepartments,
+  checkPhoneNumberExists,
   signup,
   sendVerificationCode,
   authenticateSmsCode,


### PR DESCRIPTION

<img width="1022" alt="image" src="https://github.com/user-attachments/assets/fc742556-d1b8-46d5-8038-8be64ad6e035" />

# 📋 Summary
회원가입 시 휴대폰 번호 중복 확인 기능을 추가하여 이미 가입된 사용자의 중복 가입을 방지합니다.
# 🔧 Changes Made
## 1. 휴대폰 번호 중복 확인 API 추가
 src/features/signup/apis/index.tsx에  checkPhoneNumberExists 함수 추가
/auth/check/phone-number 엔드포인트와 연동
Service 타입 및 apis 객체에 새로운 API 추가
## 2. 회원가입 전 중복 확인 로직 구현
 app/auth/signup/profile-image.tsx의 회원가입 프로세스 수정
실제 회원가입 API 호출 전 휴대폰 번호 중복 확인 수행
중복된 경우 "이미 가입된 사용자입니다" 에러 모달 표시 후 /auth/login으로 리다이렉트
중복이 아닌 경우에만 기존 회원가입 프로세스 진행
# 🔄 Flow
사용자가 프로필 이미지 업로드 완료 후 "다음으로" 버튼 클릭
휴대폰 번호 존재 여부 검증
백엔드 API로 휴대폰 번호 중복 확인 요청
중복인 경우: 에러 모달 표시 → 로그인 페이지로 리다이렉트
중복이 아닌 경우: 기존 회원가입 프로세스 계속 진행
# 🎯 Expected Behavior
이미 가입된 휴대폰 번호로 회원가입 시도 시 중복 가입 방지
사용자에게 명확한 피드백 제공
기존 사용자는 로그인 페이지로 안내