### PR TITLE
feat: 블랙리스트 기능 추가

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "sometimes",
     "slug": "sometimes",
-    "version": "1.0.9",
+    "version": "1.0.10",
     "orientation": "portrait",
     "icon": "./assets/icons/app.png",
     "scheme": "myapp",

--- a/src/features/pass/hooks/use-portone-login.ts
+++ b/src/features/pass/hooks/use-portone-login.ts
@@ -5,6 +5,8 @@ import {PortOneAuthService} from '../services/portone-auth.service';
 import {isAdult} from '../utils';
 import type {PortOneIdentityVerificationRequest, PortOneIdentityVerificationResponse} from '../types';
 import {useAuth} from '@/src/features/auth/hooks/use-auth';
+import {checkPhoneNumberBlacklist} from '@/src/features/signup/apis';
+import {useModal} from '@/src/shared/hooks/use-modal';
 
 interface UsePortOneLoginOptions {
   onError?: (error: Error) => void;
@@ -51,6 +53,7 @@ export const usePortOneLogin = ({
 
   const {loginWithPass} = useAuth();
   const authService = new PortOneAuthService();
+  const {showModal} = useModal();
 
   const clearError = useCallback(() => {
     setError(null);
@@ -65,7 +68,40 @@ export const usePortOneLogin = ({
         const {birthday} = loginResult.certificationInfo;
 
         if (!isAdult(birthday)) {
-          router.push({pathname: '/auth/age-restriction' as any});
+          router.push('/auth/age-restriction');
+          return;
+        }
+      }
+
+      if (loginResult.certificationInfo?.phone) {
+        try {
+          const {isBlacklisted} = await checkPhoneNumberBlacklist(loginResult.certificationInfo.phone);
+
+          if (isBlacklisted) {
+            showModal({
+              title: "가입 제한",
+              children: "신고 접수 또는 프로필 정보 부적합 등의 사유로 가입이 제한되었습니다.",
+              primaryButton: {
+                text: "확인",
+                onClick: () => {
+                  router.replace('/');
+                }
+              }
+            });
+            return;
+          }
+        } catch (error) {
+          console.error('블랙리스트 체크 실패:', error);
+          showModal({
+            title: "오류",
+            children: "가입 확인 중 오류가 발생했습니다. 잠시 후 다시 시도해주세요.",
+            primaryButton: {
+              text: "확인",
+              onClick: () => {
+                router.replace('/');
+              }
+            }
+          });
           return;
         }
       }
@@ -81,7 +117,7 @@ export const usePortOneLogin = ({
       router.replace('/home');
       onSuccess?.(false);
     }
-  }, [loginWithPass, onSuccess]);
+  }, [loginWithPass, onSuccess, showModal]);
 
   // 모바일 PASS 인증 완료 핸들러
   const handleMobileAuthComplete = useCallback(async (response: PortOneIdentityVerificationResponse) => {

--- a/src/features/signup/apis/index.tsx
+++ b/src/features/signup/apis/index.tsx
@@ -34,6 +34,9 @@ const createFileObject = (imageUri: string, fileName: string) =>
 export const checkPhoneNumberExists = (phoneNumber: string): Promise<{ exists: boolean }> =>
   axiosClient.post('/auth/check/phone-number', { phoneNumber });
 
+export const checkPhoneNumberBlacklist = (phoneNumber: string): Promise<{ isBlacklisted: boolean }> =>
+  axiosClient.post('/auth/check/phone-number/blacklist', { phoneNumber });
+
 export const signup = (form: SignupForm): Promise<void> => {
   const formData = new FormData();
   formData.append('phoneNumber', form.phone);
@@ -65,6 +68,7 @@ type Service = {
   getUnivs: () => Promise<string[]>;
   getDepartments: (univ: string) => Promise<string[]>;
   checkPhoneNumberExists: (phoneNumber: string) => Promise<{ exists: boolean }>;
+  checkPhoneNumberBlacklist: (phoneNumber: string) => Promise<{ isBlacklisted: boolean }>;
   signup: (form: SignupForm) => Promise<void>;
   sendVerificationCode: (phoneNumber: string) => Promise<{ uniqueKey: string }>;
   authenticateSmsCode: (smsCode: AuthorizeSmsCode) => Promise<void>;
@@ -78,6 +82,7 @@ const apis: Service = {
   getUnivs,
   getDepartments,
   checkPhoneNumberExists,
+  checkPhoneNumberBlacklist,
   signup,
   sendVerificationCode,
   authenticateSmsCode,


### PR DESCRIPTION
### 배경

이 PR은 **PASS 인증**으로 전환하는 과정에서 의도치 않게 제거되었던 블랙리스트 확인 기능을 다시 추가합니다. 이전에는 블랙리스트 확인이 **SMS 인증**과 연결되어 있었는데, SMS 인증이 PASS로 대체되면서 이 중요한 기능이 사라졌습니다.

### 변경 사항

* **블랙리스트 API 연결**: 회원가입 시도 시 블랙리스트 여부를 확인하고 블랙리스트 유저일때 회원가입을 막습니다.

### 영향

이번 변경으로 중요한 보안 기능이 복원되어 블랙리스트에 있는 사용자를 효과적으로 관리하고 식별할 수 있게 되었습니다.