### PR TITLE
feat: 사라진 블랙리스트 기능 추가

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "sometimes",
     "slug": "sometimes",
-    "version": "1.2.4",
+    "version": "1.2.5",
     "orientation": "portrait",
     "icon": "./assets/icons/app.png",
     "scheme": "myapp",

--- a/src/features/signup/apis/index.tsx
+++ b/src/features/signup/apis/index.tsx
@@ -37,6 +37,11 @@ export const checkPhoneNumberExists = (
 ): Promise<{ exists: boolean }> =>
   axiosClient.post("/auth/check/phone-number", { phoneNumber });
 
+export const checkPhoneNumberBlacklist = (
+  phoneNumber: string
+): Promise<{ isBlacklisted: boolean }> =>
+  axiosClient.post("/auth/check/phone-number/blacklist", { phoneNumber });
+
 export const signup = (form: SignupForm): Promise<void> => {
   const formData = new FormData();
   formData.append("phoneNumber", form.phone);
@@ -68,6 +73,7 @@ type Service = {
   getUnivs: () => Promise<string[]>;
   getDepartments: (univ: string) => Promise<string[]>;
   checkPhoneNumberExists: (phoneNumber: string) => Promise<{ exists: boolean }>;
+  checkPhoneNumberBlacklist: (phoneNumber: string) => Promise<{ isBlacklisted: boolean }>;
   signup: (form: SignupForm) => Promise<void>;
   sendVerificationCode: (phoneNumber: string) => Promise<{ uniqueKey: string }>;
   authenticateSmsCode: (smsCode: AuthorizeSmsCode) => Promise<void>;
@@ -82,6 +88,7 @@ const apis: Service = {
   getUnivs,
   getDepartments,
   checkPhoneNumberExists,
+  checkPhoneNumberBlacklist,
   signup,
   sendVerificationCode,
   authenticateSmsCode,


### PR DESCRIPTION
### 배경
이 PR은 *PASS 인증*으로 전환하는 과정에서 의도치 않게 제거되었던 블랙리스트 확인 기능을 다시 추가합니다. 이전에는 블랙리스트 확인이 *SMS 인증*과 연결되어 있었는데, SMS 인증이 PASS로 대체되면서 이 중요한 기능이 사라졌습니다.
### 변경 사항
• 블랙리스트 API 연결: 회원가입 시도 시 블랙리스트 여부를 확인하고 블랙리스트 유저일때 회원가입을 막습니다.
### 영향
이번 변경으로 중요한 보안 기능이 복원되어 블랙리스트에 있는 사용자를 효과적으로 관리하고 식별할 수 있게 되었습니다.