### PR TITLE
fix: 회원가입 시 대학교 정보 스크롤뷰로 나오게 수정

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "sometimes",
     "slug": "sometimes",
-    "version": "1.2.5",
+    "version": "1.2.6",
     "orientation": "portrait",
     "icon": "./assets/icons/app.png",
     "scheme": "myapp",

--- a/app/auth/signup/university.tsx
+++ b/app/auth/signup/university.tsx
@@ -6,7 +6,7 @@ import { ChipSelector, LabelInput } from '@/src/widgets';
 import { Image } from 'expo-image';
 import { router, useLocalSearchParams } from 'expo-router';
 import { useState, useEffect, useRef } from 'react';
-import { KeyboardAvoidingView, View } from 'react-native';
+import { KeyboardAvoidingView, View, ScrollView, StyleSheet } from 'react-native';
 import Loading from "@features/loading";
 import { useKeyboarding } from '@shared/hooks';
 
@@ -104,14 +104,14 @@ export default function UniversityPage() {
           title="학교를 검색중이에요"
           loading={isLoading}
         >
-          <View className="w-full">
+          <ScrollView style={styles.chipContainer} contentContainerStyle={styles.chipScrollContent}>
             <ChipSelector
               value={selectedUniv}
               options={filteredUnivs.map((univ) => ({ label: univ, value: univ }))}
               onChange={setSelectedUniv}
               className="w-full"
             />
-          </View>
+          </ScrollView>
         </Loading.Lottie>
       </View>
 
@@ -139,3 +139,14 @@ export default function UniversityPage() {
     </KeyboardAvoidingView>
   );
 }
+
+const styles = StyleSheet.create({
+  chipContainer: {
+    marginTop: 4,
+    width: '100%',
+    maxHeight: 400,
+  },
+  chipScrollContent: {
+    flexGrow: 1,
+  },
+});


### PR DESCRIPTION
## 구현 내용:
ScrollView import 추가: ScrollView와 StyleSheet를 React Native에서 import
ChipSelector를 ScrollView로 감쌈: 대학교 목록이 많을 때 스크롤 가능하도록 구현
## 스타일 추가:
chipContainer: 최대 높이 400px로 제한하여 화면을 넘지 않도록 함
chipScrollContent: 스크롤 컨텐츠가 적절히 늘어나도록 설정