### PR TITLE
hotfix: 설정 헤더 뒤로가기로 변경

### DIFF
--- a/src/features/setting/ui/setting-header.tsx
+++ b/src/features/setting/ui/setting-header.tsx
@@ -15,7 +15,7 @@ function SettingHeader() {
       <Header.LeftContent>
         <Pressable
           onPress={() => {
-            router.navigate("/my");
+            router.back();
           }}
           style={styles.arrowContainer}
         >


### PR DESCRIPTION
- 설정 헤더 뒤로가기 router.navigate("/my") -> router.back()  뎁스 고려를 못함 