### PR TITLE
feat: 개발자 로그인 및 지역 제한 개선

### DIFF
--- a/app/home/_layout.tsx
+++ b/app/home/_layout.tsx
@@ -1,25 +1,18 @@
-import { Stack, router } from 'expo-router';
-import { View } from 'react-native';
-import { useEffect, useState } from 'react';
-import { useAuth } from '@/src/features/auth/hooks/use-auth';
-import { getUserStatus } from '@/src/features/auth/apis';
-import { useCheckBusanQuery } from '@/src/features/home/queries';
+import {Stack, router} from 'expo-router';
+import {View} from 'react-native';
+import {useEffect, useState} from 'react';
+import {useAuth} from '@/src/features/auth/hooks/use-auth';
+import {getUserStatus} from '@/src/features/auth/apis';
+import {useCheckBusanQuery} from '@/src/features/home/queries';
 import Loading from '@/src/features/loading';
 
 export default function HomeLayout() {
-  const { my } = useAuth();
+  const {my} = useAuth();
   const [statusChecked, setStatusChecked] = useState(false);
-  // TODO: 부산 유저 임시 체크라 나중에 제거해야함
-  const shouldCheckBusan = !!my;
-  const { data: isBusan = false, isLoading: isBusanLoading } = useCheckBusanQuery(shouldCheckBusan);
 
   useEffect(() => {
     const checkApprovalStatus = async () => {
-      if (!my?.phoneNumber || statusChecked || isBusanLoading) return;
-      if (isBusan) {
-        router.replace('/commingsoon');
-        return;
-      }
+      if (!my?.phoneNumber || statusChecked) return;
 
       try {
         const statusData = await getUserStatus(my.phoneNumber);
@@ -47,25 +40,25 @@ export default function HomeLayout() {
     };
 
     checkApprovalStatus();
-  }, [my?.phoneNumber, statusChecked, isBusan, isBusanLoading]);
+  }, [my?.phoneNumber, statusChecked]);
 
-  if (!statusChecked || isBusanLoading) {
-    return <Loading.Page title="사용자 정보를 확인하고 있어요..." />;
+  if (!statusChecked) {
+    return <Loading.Page title="사용자 정보를 확인하고 있어요..."/>;
   }
 
   return (
-    <View className="flex-1">
-      <Stack>
-        <Stack.Screen
-          name="index"
-          options={{
-            headerShown: false,
-            contentStyle: {
-              backgroundColor: 'transparent',
-            },
-          }}
-        />
-      </Stack>
-    </View>
+      <View className="flex-1">
+        <Stack>
+          <Stack.Screen
+              name="index"
+              options={{
+                headerShown: false,
+                contentStyle: {
+                  backgroundColor: 'transparent',
+                },
+              }}
+          />
+        </Stack>
+      </View>
   );
 }

--- a/src/features/auth/ui/email-login-modal.tsx
+++ b/src/features/auth/ui/email-login-modal.tsx
@@ -1,0 +1,149 @@
+import React, {useState} from 'react';
+import {View, StyleSheet, Modal} from 'react-native';
+import {Text, Button, Input} from '@/src/shared/ui';
+import {useAuth} from '@/src/features/auth/hooks/use-auth';
+import {tryCatch} from '@/src/shared/libs';
+import {router} from 'expo-router';
+import colors from "@constants/colors";
+
+interface EmailLoginModalProps {
+  isVisible: boolean;
+  onClose: () => void;
+}
+
+export function EmailLoginModal({isVisible, onClose}: EmailLoginModalProps) {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const {login} = useAuth();
+
+  const handleLogin = async () => {
+    if (!email.trim() || !password.trim()) {
+      return;
+    }
+
+    setIsLoading(true);
+    await tryCatch(
+        async () => {
+          await login(email, password);
+          onClose();
+          router.replace('/home');
+        },
+        (error) => {
+          console.error('Login failed:', error);
+        }
+    );
+    setIsLoading(false);
+  };
+
+  const handleClose = () => {
+    setEmail('');
+    setPassword('');
+    setIsLoading(false);
+    onClose();
+  };
+
+  return (
+      <Modal
+          visible={isVisible}
+          transparent
+          animationType="fade"
+          onRequestClose={handleClose}
+      >
+        <View style={styles.overlay}>
+          <View style={styles.container}>
+            <Text style={styles.title}>이메일 로그인</Text>
+
+            <View style={styles.inputContainer}>
+              <Input
+                  placeholder="이메일"
+                  value={email}
+                  onChangeText={setEmail}
+                  keyboardType="email-address"
+                  autoCapitalize="none"
+                  editable={!isLoading}
+              />
+
+              <Input
+                  placeholder="비밀번호"
+                  value={password}
+                  onChangeText={setPassword}
+                  isPassword
+                  editable={!isLoading}
+              />
+            </View>
+
+            <View style={styles.buttonContainer}>
+              <Button
+                  onPress={handleClose}
+                  styles={styles.button}
+                  disabled={isLoading}
+              >취소</Button>
+              <Button
+                  onPress={handleLogin}
+                  styles={styles.loginButton}
+                  disabled={isLoading || !email.trim() || !password.trim()}
+              >{isLoading ? "로그인 중..." : "로그인"}</Button>
+            </View>
+          </View>
+        </View>
+      </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0, 0, 0, 0.5)',
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingHorizontal: 20,
+  },
+  container: {
+    backgroundColor: colors.white,
+    borderRadius: 12,
+    padding: 24,
+    width: '100%',
+    maxWidth: 320,
+  },
+  title: {
+    fontSize: 18,
+    fontWeight: '600',
+    color: colors.black,
+    textAlign: 'center',
+    marginBottom: 20,
+  },
+  inputContainer: {
+    gap: 12,
+    marginBottom: 24,
+  },
+  buttonContainer: {
+    flexDirection: 'row',
+    gap: 12,
+  },
+  button: {
+    flex: 1,
+    paddingVertical: 12,
+    borderRadius: 8,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  cancelButton: {
+    backgroundColor: colors["gray-300"],
+    borderWidth: 1,
+    borderColor: colors["gray-300"],
+  },
+  cancelButtonText: {
+    color: colors["gray-600"],
+    fontSize: 16,
+    fontWeight: '500',
+  },
+  loginButton: {
+    backgroundColor: colors.primaryPurple,
+  },
+  loginButtonText: {
+    color: colors.white,
+    fontSize: 16,
+    fontWeight: '600',
+  },
+});

--- a/src/features/signup/ui/logo.tsx
+++ b/src/features/signup/ui/logo.tsx
@@ -1,6 +1,5 @@
 import {IconWrapper} from "@/src/shared/ui/icons";
 import {View, Animated, Pressable} from "react-native";
-import LogoIcon from '@/assets/icons/paper-plane.svg';
 import SmallTitle from '@/assets/icons/small-title.svg';
 import {Text} from "@/src/shared/ui";
 import {cn} from "@/src/shared/libs/cn";
@@ -8,10 +7,11 @@ import {platform} from "@/src/shared/libs/platform";
 import {Image} from "expo-image";
 import {useRef, useState} from "react";
 import {AppleReviewModal} from "@/src/features/auth/ui/apple-review-modal";
-
+import {EmailLoginModal} from "@/src/features/auth/ui/email-login-modal";
 
 export default function Logo() {
   const [isModalVisible, setIsModalVisible] = useState(false);
+  const [isEmailLoginModalVisible, setIsEmailLoginModalVisible] = useState(false);
   const [longPressTimeout, setLongPressTimeout] = useState<ReturnType<typeof setTimeout> | null>(null);
   const rotationValue = useRef(new Animated.Value(0)).current;
 
@@ -76,12 +76,22 @@ export default function Logo() {
           <SmallTitle/>
         </IconWrapper>
         <View className="items-center pt-[8px] flex flex-col gap-y-[6px]">
-          <Text className="text-[15px] text-primaryPurple">익숙한 하루에 설렘 하나</Text>
+          <Pressable
+              onLongPress={() => setIsEmailLoginModalVisible(true)}
+              delayLongPress={2000}
+          >
+            <Text className="text-[15px] text-primaryPurple">익숙한 하루에 설렘 하나</Text>
+          </Pressable>
         </View>
 
         <AppleReviewModal
             isVisible={isModalVisible}
             onClose={() => setIsModalVisible(false)}
+        />
+
+        <EmailLoginModal
+            isVisible={isEmailLoginModalVisible}
+            onClose={() => setIsEmailLoginModalVisible(false)}
         />
       </View>
   );

--- a/src/shared/libs/axios.ts
+++ b/src/shared/libs/axios.ts
@@ -1,15 +1,21 @@
 import axios from 'axios';
-import { storage } from './store';
-import type { TokenResponse } from '@/src/types/auth';
-import { tryCatch } from './try-catch';
-import { router } from 'expo-router';
-import { eventBus } from './event-bus';
+import {storage} from './store';
+import type {TokenResponse} from '@/src/types/auth';
+import {tryCatch} from './try-catch';
+import {router} from 'expo-router';
+import {eventBus} from './event-bus';
 
 let refreshTokenPromise: Promise<string> | null = null;
+let isNetworkDisabled = false;
 const detach = (token: string) => token.replaceAll('\"', '');
 const TokenErrorExceptPaths = [
   '/community',
 ];
+
+export enum ErrorCode {
+  REGION_NOT_ALLOWED = 'REGION_NOT_ALLOWED',
+}
+
 
 const refresh = async () => {
   if (refreshTokenPromise) {
@@ -21,15 +27,15 @@ const refresh = async () => {
       const refreshToken = await storage.getItem('refresh-token');
       if (!refreshToken) throw new Error('No refresh token');
 
-      const { accessToken, refreshToken: newRefreshToken } = await temporaryAxiosClient
-        .post<TokenResponse>('/auth/refresh', { refreshToken: detach(refreshToken) })
-        .then(response => response.data);
+      const {accessToken, refreshToken: newRefreshToken} = await temporaryAxiosClient
+          .post<TokenResponse>('/auth/refresh', {refreshToken: detach(refreshToken)})
+          .then(response => response.data);
 
       await storage.setItem('access-token', accessToken);
       await storage.setItem('refresh-token', newRefreshToken);
 
       // 토큰 갱신 이벤트 발생
-      eventBus.emit('auth:tokensUpdated', { accessToken, refreshToken: newRefreshToken });
+      eventBus.emit('auth:tokensUpdated', {accessToken, refreshToken: newRefreshToken});
 
       return accessToken;
     } finally {
@@ -44,7 +50,7 @@ const axiosClient = axios.create({
   baseURL: process.env.EXPO_PUBLIC_API_URL,
   timeout: 10000,
   headers: {
-    'Content-Type': 'application/json'    
+    'Content-Type': 'application/json'
   },
 });
 
@@ -58,65 +64,75 @@ const temporaryAxiosClient = axios.create({
 
 // 요청 인터셉터
 axiosClient.interceptors.request.use(
-  async (config) => {
-    const accessToken = await storage.getItem('access-token');
-    config.headers.Authorization = `Bearer ${accessToken?.replaceAll('\"', '')}`;
-    return config;
-  },
-  (error) => {
-    return Promise.reject(error);
-  }
+    async (config) => {
+      if (isNetworkDisabled) {
+        return Promise.reject(new Error('Network requests are disabled due to REGION_NOT_ALLOWED'));
+      }
+      const accessToken = await storage.getItem('access-token');
+      config.headers.Authorization = `Bearer ${accessToken?.replaceAll('\"', '')}`;
+      return config;
+    },
+    (error) => {
+      return Promise.reject(error);
+    }
 );
 
 // 응답 인터셉터
 axiosClient.interceptors.response.use(
-  (response) => {
-    return response.data;
-  },
-  async (error) => {
-    if (error.status === 401) {
-      try {
-        const newAccessToken = await refresh();
-        error.config.headers.Authorization = `Bearer ${newAccessToken}`;
+    (response) => {
+      return response.data;
+    },
+    async (error) => {
+      const data = error?.response?.data;
+      if (error.status === 403 && data.code === ErrorCode.REGION_NOT_ALLOWED) {
+        isNetworkDisabled = true;
+        router.push('/commingsoon');
+        return;
+      }
 
-        return await tryCatch(async () => {
-          const result = await temporaryAxiosClient(error.config);
-          return result.data;
-        }, (error) => {
-          console.log({ refreshError: error })
+      if (error.status === 401) {
+        try {
+          const newAccessToken = await refresh();
+          error.config.headers.Authorization = `Bearer ${newAccessToken}`;
+
+          return await tryCatch(async () => {
+            const result = await temporaryAxiosClient(error.config);
+            return result.data;
+          }, (error) => {
+            console.log({refreshError: error})
+            storage.removeItem('access-token');
+            storage.removeItem('refresh-token');
+            eventBus.emit('auth:logout');
+            console.error(error);
+            router.push('/auth/login');
+          });
+        } catch (refreshError) {
+          const currentPath = await storage.getItem('current-path');
+          console.table({
+            currentPath,
+          });
+
+          const justPropagateError = TokenErrorExceptPaths.some(path => currentPath?.includes(path));
+          if (justPropagateError) {
+            return Promise.reject(refreshError);
+          }
+
           storage.removeItem('access-token');
           storage.removeItem('refresh-token');
+          // 로그아웃 이벤트 발생
           eventBus.emit('auth:logout');
-          console.error(error);
           router.push('/auth/login');
-        });
-      } catch (refreshError) {
-        const currentPath = await storage.getItem('current-path');
-        console.table({
-          currentPath,
-        });
-
-        const justPropagateError = TokenErrorExceptPaths.some(path => currentPath?.includes(path));
-        if (justPropagateError) {
           return Promise.reject(refreshError);
         }
-
-        storage.removeItem('access-token');
-        storage.removeItem('refresh-token');
-        // 로그아웃 이벤트 발생
-        eventBus.emit('auth:logout');
-        router.push('/auth/login');
-        return Promise.reject(refreshError);
       }
+
+      const payload = {
+        ...error.response?.data,
+        status: error.response?.status,
+      };
+
+      return Promise.reject(payload);
     }
-
-    const payload = {
-      ...error.response?.data,
-      status: error.response?.status,
-    };
-
-    return Promise.reject(payload);
-  }
 );
 
 export default axiosClient; 


### PR DESCRIPTION
## Summary
- 개발자용 이메일 로그인 기능 추가 ("익숙한 하루에 설렘 하나" 2초 길게 누르기)
- REGION_NOT_ALLOWED 발생 시 모든 네트워크 요청 비활성화 처리 개선
- 기존 UI 단 부산 유저 체크 로직 제거

## 주요 변경사항
### 1. 개발자 로그인 기능 추가
- `src/features/signup/ui/logo.tsx`: "익숙한 하루에 설렘 하나" 텍스트 2초 길게 누르기 감지
- `src/features/auth/ui/email-login-modal.tsx`: 이메일/비밀번호 입력 모달 컴포넌트 생성
- 로그인 성공 시 자동으로 홈으로 리다이렉션

### 2. 지역 제한 네트워크 처리 개선
- `src/shared/libs/axios.ts`: REGION_NOT_ALLOWED 발생 시 `isNetworkDisabled` 플래그로 모든 후속 요청 차단
- 요청 인터셉터에서 네트워크 비활성화 상태 체크하여 조기 차단

### 3. UI 로직 정리
- 홈 화면에서 기존 부산 유저 체크 로직 제거
- 매칭 히스토리 컴포넌트 추가

## Test plan
- [ ] "익숙한 하루에 설렘 하나" 텍스트 2초 길게 누르기 시 로그인 모달 표시 확인
- [ ] 이메일/비밀번호 입력 후 로그인 성공 시 홈으로 리다이렉션 확인
- [ ] REGION_NOT_ALLOWED 발생 시 후속 네트워크 요청 차단 확인
- [ ] 홈 화면 정상 렌더링 확인

🤖 Generated with [Claude Code](https://claude.ai/code)