### PR TITLE
Feat: 회원가입 Amplitude 트랙 추가

### DIFF
--- a/app/auth/signup/area.tsx
+++ b/app/auth/signup/area.tsx
@@ -5,6 +5,7 @@ import { areaMap } from "@/src/features/signup/lib";
 import Heart from "@/src/features/signup/ui/area/heart";
 import AreaModal from "@/src/features/signup/ui/area/modal";
 import { Button, Header, Text } from "@/src/shared/ui";
+import { track } from "@amplitude/analytics-react-native";
 import AreaFillHeart from "@assets/icons/area-fill-heart.svg";
 import DokdoIcon from "@assets/icons/dokdo.svg";
 import { Image } from "expo-image";
@@ -25,6 +26,7 @@ function Area() {
 
   const handleNext = () => {
     onNext(() => {
+      track("Signup_area", { area: show });
       router.push("/auth/signup/university");
     });
   };

--- a/app/auth/signup/done.tsx
+++ b/app/auth/signup/done.tsx
@@ -3,6 +3,7 @@ import Signup from "@/src/features/signup";
 import { environmentStrategy } from "@/src/shared/libs";
 import { Button, PalePurpleGradient, Text } from "@/src/shared/ui";
 import { IconWrapper } from "@/src/shared/ui/icons";
+import { track } from "@amplitude/analytics-react-native";
 import { Image } from "expo-image";
 import { router } from "expo-router";
 import { View } from "react-native";
@@ -15,6 +16,7 @@ export default function SignupDoneScreen() {
 
   const onNext = () => {
     trackSignupEvent("completion_button_click");
+    track("Signup_done");
     clear();
     router.push("/auth/login");
   };
@@ -53,7 +55,7 @@ export default function SignupDoneScreen() {
         </View>
       </View>
 
-      <View className="w-full px-5 mb-[14px] md:mb-[58px]">
+      <View className="w-full px-5 mb-[18px] md:mb-[58px]">
         <Button variant="primary" size="md" onPress={onNext} className="w-full">
           이상형 찾으러 가기 →
         </Button>

--- a/app/auth/signup/profile-image.tsx
+++ b/app/auth/signup/profile-image.tsx
@@ -9,6 +9,7 @@ import { platform } from "@/src/shared/libs/platform";
 import { Button, ImageSelector } from "@/src/shared/ui";
 import { PalePurpleGradient } from "@/src/shared/ui/gradient";
 import { Text } from "@/src/shared/ui/text";
+import { track } from "@amplitude/analytics-react-native";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Image } from "expo-image";
 import { router } from "expo-router";
@@ -69,6 +70,9 @@ export default function ProfilePage() {
         if (!signupForm.phone) {
           showErrorModal("휴대폰 번호가 없습니다", "announcement");
           trackSignupEvent("signup_error", "missing_phone");
+          track("Signup_profile_image_error", {
+            error: "휴대폰 번호가 없습니다.",
+          });
           router.push("/auth/login");
           return;
         }
@@ -77,17 +81,23 @@ export default function ProfilePage() {
 
         if (exists) {
           showErrorModal("이미 가입된 사용자입니다", "announcement");
+          track("Signup_profile_image_error", {
+            error: "이미 가입된 사용자입니다",
+          });
           trackSignupEvent("signup_error", "phone_already_exists");
+
           router.push("/auth/login");
           return;
         }
 
         await apis.signup(signupForm as SignupForm);
+        track("Signup_profile_image", { success: true });
         trackSignupEvent("signup_complete");
         router.push("/auth/signup/done");
       },
       (error) => {
         console.error("Signup error:", error);
+        track("Signup_profile_image_error", { error: error });
         trackSignupEvent("signup_error", error.error);
         showErrorModal(error.error, "announcement");
       }
@@ -146,6 +156,7 @@ export default function ProfilePage() {
             value={images[0] ?? undefined}
             onChange={(value) => {
               trackSignupEvent("image_upload", "image_1");
+              track("Signup_profile_image_1");
               uploadImage(0, value);
               form.trigger("images");
             }}
@@ -158,6 +169,7 @@ export default function ProfilePage() {
             value={images[1] ?? undefined}
             onChange={(value) => {
               trackSignupEvent("image_upload", "image_2");
+              track("Signup_profile_image_2");
               uploadImage(1, value);
               form.trigger("images");
             }}
@@ -167,6 +179,7 @@ export default function ProfilePage() {
             value={images[2] ?? undefined}
             onChange={(value) => {
               trackSignupEvent("image_upload", "image_3");
+              track("Signup_profile_image_3");
               uploadImage(2, value);
               form.trigger("images");
             }}

--- a/app/auth/signup/university-details.tsx
+++ b/app/auth/signup/university-details.tsx
@@ -11,6 +11,7 @@ import { Button, Label, Show } from "@/src/shared/ui";
 import { PalePurpleGradient } from "@/src/shared/ui/gradient";
 import { Text } from "@/src/shared/ui/text";
 import { Form } from "@/src/widgets";
+import { track } from "@amplitude/analytics-react-native";
 import Loading from "@features/loading";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Image } from "expo-image";
@@ -125,6 +126,12 @@ export default function UniversityDetailsPage() {
 
   const onNext = handleSubmit(async (data) => {
     trackSignupEvent("next_button_click", "to_done");
+    track("Singup_university_details", {
+      instagramId: data.instagramId,
+      grade: data.grade,
+      department: data.departmentName,
+      studentNumber: data.studentNumber,
+    });
     setSignupLoading(true);
     await tryCatch(
       async () => {
@@ -135,6 +142,9 @@ export default function UniversityDetailsPage() {
         router.push("/auth/signup/profile-image");
       },
       (error) => {
+        track("Singup_university_details_error", {
+          error: "에러 발생",
+        });
         setSignupLoading(false);
         console.log(error);
         trackSignupEvent("signup_error", error.error);

--- a/app/auth/signup/university.tsx
+++ b/app/auth/signup/university.tsx
@@ -5,6 +5,7 @@ import { filterUniversities } from "@/src/features/signup/lib";
 import useUniversities from "@/src/features/signup/queries/use-universities";
 import SearchUniversity from "@/src/features/signup/ui/university/search-university";
 import UniversityCard from "@/src/features/signup/ui/university/university-card";
+import { track } from "@amplitude/analytics-react-native";
 
 import HelpIcon from "@assets/icons/help.svg";
 import Loading from "@features/loading";
@@ -35,6 +36,7 @@ export default function UniversityPage() {
 
   const handleNext = () => {
     onNext(() => {
+      track("Signup_university", { test: true, university: selectedUniv });
       router.push(
         `/auth/signup/university-details?universityName=${selectedUniv}`
       );

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
 				"@lottiefiles/dotlottie-react": "^0.13.5",
 				"@portone/browser-sdk": "^0.0.17",
 				"@portone/react-native-sdk": "^0.5.0",
-				"@react-native-async-storage/async-storage": "^2.2.0",
+				"@react-native-async-storage/async-storage": "^2.1.2",
 				"@react-native-firebase/analytics": "^22.4.0",
 				"@react-native-firebase/app": "^22.4.0",
 				"@react-native-masked-view/masked-view": "^0.3.2",
@@ -152,7 +152,6 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/@amplitude/analytics-react-native/-/analytics-react-native-1.5.0.tgz",
 			"integrity": "sha512-Mj7utntebyzpij23i+/mu5KIsz/NuKXUt8GbtYFzstMamxH4JetQ264KQV/QpUCBQZWwgPfiJ3XTs+Zb9Zow1g==",
-			"license": "MIT",
 			"dependencies": {
 				"@amplitude/analytics-core": "^2.19.0",
 				"@amplitude/ua-parser-js": "^0.7.31",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
 		"build:ios:prod": "cross-env APP_ENV=production node ./scripts/build-ios.js"
 	},
 	"dependencies": {
+		"@amplitude/analytics-react-native": "^1.5.0",
 		"@babel/plugin-proposal-export-namespace-from": "^7.18.9",
 		"@expo/config-plugins": "^10.0.2",
 		"@expo/vector-icons": "^14.0.2",
@@ -44,6 +45,7 @@
 		"expo": "53.0.12",
 		"expo-application": "~6.1.5",
 		"expo-blur": "~14.1.4",
+		"expo-build-properties": "~0.14.8",
 		"expo-calendar": "~14.1.4",
 		"expo-camera": "~16.1.6",
 		"expo-constants": "~17.1.7",
@@ -56,6 +58,7 @@
 		"expo-intent-launcher": "~12.1.4",
 		"expo-linear-gradient": "~14.1.4",
 		"expo-linking": "~7.1.5",
+		"expo-location": "~18.1.6",
 		"expo-media-library": "~17.1.7",
 		"expo-notifications": "~0.31.4",
 		"expo-router": "~5.1.0",
@@ -91,12 +94,7 @@
 		"ts-pattern": "^5.7.1",
 		"tw-merge": "^0.0.1-alpha.3",
 		"zod": "^3.24.2",
-		"zustand": "^5.0.3",
-		"expo-build-properties": "~0.14.8",
-		"expo-notifications": "~0.31.4",
-		"expo-device": "~7.1.4",
-		"@shopify/flash-list": "1.7.6",
-		"expo-location": "~18.1.6"
+		"zustand": "^5.0.3"
 	},
 	"devDependencies": {
 		"@babel/core": "^7.25.2",

--- a/src/features/signup/ui/login-form.tsx
+++ b/src/features/signup/ui/login-form.tsx
@@ -1,8 +1,12 @@
-import {View, TouchableOpacity, Platform} from "react-native";
-import {Text, Button} from "@/src/shared/ui";
-import {usePortOneLogin, MobileIdentityVerification} from "@/src/features/pass";
+import {
+  MobileIdentityVerification,
+  usePortOneLogin,
+} from "@/src/features/pass";
+import { Button, Text } from "@/src/shared/ui";
+import { track } from "@amplitude/analytics-react-native";
+import { Platform, TouchableOpacity, View } from "react-native";
+import { PrivacyNotice } from "../../auth/ui/privacy-notice";
 import UniversityLogos from "./university-logos";
-import {PrivacyNotice} from "../../auth/ui/privacy-notice";
 
 export default function LoginForm() {
   const {
@@ -17,60 +21,61 @@ export default function LoginForm() {
   } = usePortOneLogin();
 
   const onPressPassLogin = async () => {
+    track("Signup_Init", { test: true });
+
     clearError();
     await startPortOneLogin();
   };
 
   // 모바일에서 PASS 인증 화면 표시
-  if (showMobileAuth && mobileAuthRequest && Platform.OS !== 'web') {
+  if (showMobileAuth && mobileAuthRequest && Platform.OS !== "web") {
     return (
-        <MobileIdentityVerification
-            request={mobileAuthRequest}
-            onComplete={handleMobileAuthComplete}
-            onError={handleMobileAuthError}
-        />
+      <MobileIdentityVerification
+        request={mobileAuthRequest}
+        onComplete={handleMobileAuthComplete}
+        onError={handleMobileAuthError}
+      />
     );
   }
 
   return (
-      <View className="flex flex-col flex-1 items-center">
-        {/* 대학교 로고 애니메이션 */}
-        <UniversityLogos logoSize={64}/>
+    <View className="flex flex-col flex-1 items-center">
+      {/* 대학교 로고 애니메이션 */}
+      <UniversityLogos logoSize={64} />
 
-        {/* 회원가입 및 로그인 버튼 */}
-        <View className="flex flex-col">
-          <View className="w-full max-w-xs mt-6">
-            <Button
-                variant="primary"
-                width="full"
-                onPress={onPressPassLogin}
-                disabled={isLoading}
-                className="py-4 rounded-full min-w-[280px] min-h-[60px]"
-            >
-              <Text className="text-white text-center text-[18px] h-[40px]">
-                {isLoading ? 'PASS 인증 중...' : '회원가입 및 로그인'}
-              </Text>
-            </Button>
-          </View>
-        </View>
-
-        {/* 에러 메시지 */}
-        {error && (
-            <TouchableOpacity
-                className="w-full px-6 mt-4"
-                onPress={clearError}
-            >
-              <View className="w-full px-4 py-2 bg-red-50 rounded-md">
-                <Text className="text-red-600 text-sm text-center">{error}</Text>
-                <Text className="text-red-400 text-xs text-center mt-1">탭하여 닫기</Text>
-              </View>
-            </TouchableOpacity>
-        )}
-
-        {/* 약관 동의 안내 */}
-        <View className="w-full px-6 mt-12">
-          <PrivacyNotice/>
+      {/* 회원가입 및 로그인 버튼 */}
+      <View className="flex flex-col">
+        <View className="w-full max-w-xs mt-6">
+          <Button
+            variant="primary"
+            width="full"
+            onPress={onPressPassLogin}
+            disabled={isLoading}
+            className="py-4 rounded-full min-w-[280px] min-h-[60px]"
+          >
+            <Text className="text-white text-center text-[18px] h-[40px]">
+              {isLoading ? "PASS 인증 중..." : "회원가입 및 로그인"}
+            </Text>
+          </Button>
         </View>
       </View>
-  )
+
+      {/* 에러 메시지 */}
+      {error && (
+        <TouchableOpacity className="w-full px-6 mt-4" onPress={clearError}>
+          <View className="w-full px-4 py-2 bg-red-50 rounded-md">
+            <Text className="text-red-600 text-sm text-center">{error}</Text>
+            <Text className="text-red-400 text-xs text-center mt-1">
+              탭하여 닫기
+            </Text>
+          </View>
+        </TouchableOpacity>
+      )}
+
+      {/* 약관 동의 안내 */}
+      <View className="w-full px-6 mt-12">
+        <PrivacyNotice />
+      </View>
+    </View>
+  );
 }

--- a/src/shared/ui/image-selector/index.tsx
+++ b/src/shared/ui/image-selector/index.tsx
@@ -79,6 +79,19 @@ export function ImageSelector({
     });
     console.log("image result", result);
     if (!result.canceled) {
+      const uri = result.assets[0].uri;
+      const extension = uri.split(".").pop()?.toLowerCase();
+
+      const allowedExtensions = ["jpg", "jpeg", "png"];
+      if (!extension || !allowedExtensions.includes(extension)) {
+        Alert.alert(
+          "지원하지 않는 형식",
+          "jpg, jpeg, png 형식만 업로드 가능해요"
+        );
+        setImageModal(false);
+        return null;
+      }
+
       onChange(result.assets[0].uri);
     }
     setImageModal(false);
@@ -109,6 +122,19 @@ export function ImageSelector({
     }
 
     if (!result.canceled) {
+      const uri = result.assets[0].uri;
+      const extension = uri.split(".").pop()?.toLowerCase();
+
+      const allowedExtensions = ["jpg", "jpeg", "png"];
+      if (!extension || !allowedExtensions.includes(extension)) {
+        Alert.alert(
+          "지원하지 않는 형식",
+          "jpg, jpeg, png 형식만 업로드 가능해요."
+        );
+        setImageModal(false);
+        return null;
+      }
+
       onChange(result.assets[0].uri);
     }
     setImageModal(false);

--- a/src/widgets/form/image-selector.tsx
+++ b/src/widgets/form/image-selector.tsx
@@ -59,6 +59,19 @@ export function FormImageSelector({
     });
     console.log("image result", result);
     if (!result.canceled) {
+      const uri = result.assets[0].uri;
+      const extension = uri.split(".").pop()?.toLowerCase();
+
+      const allowedExtensions = ["jpg", "jpeg", "png"];
+      if (!extension || !allowedExtensions.includes(extension)) {
+        Alert.alert(
+          "지원하지 않는 형식",
+          "jpg, jpeg, png 형식만 업로드 가능해요."
+        );
+        setImageModal(false);
+        return null;
+      }
+
       onChange(result.assets[0].uri);
     }
     setImageModal(false);
@@ -89,6 +102,19 @@ export function FormImageSelector({
     }
 
     if (!result.canceled) {
+      const uri = result.assets[0].uri;
+      const extension = uri.split(".").pop()?.toLowerCase();
+
+      const allowedExtensions = ["jpg", "jpeg", "png"];
+      if (!extension || !allowedExtensions.includes(extension)) {
+        Alert.alert(
+          "지원하지 않는 형식",
+          "jpg, jpeg, png 형식만 업로드 가능해요."
+        );
+        setImageModal(false);
+        return null;
+      }
+
       onChange(result.assets[0].uri);
     }
     setImageModal(false);


### PR DESCRIPTION
### Amplitude track 추가
회원가입 과정에서 유저의 이탈률과 이탈하는 포인트를 알기 위해 @amplitude/analytics-react-native 의 track 함수를 사용하였습니다.
(Amplitude에 대한 sdk 문서 참조 : [Amplitude SDK](https://amplitude.com/docs/sdks/analytics))
track의 플로우는 아래와 같습니다.

####

#### 패스 로그인 부분
인증 시작 | Signup_IdentityVerification_Started | 진입
인증 성공 | Signup_IdentityVerification_Completed | PASS 인증 성공
인증 실패 | Signup_IdentityVerification_Failed | 인증 실패
나이 제한 | Signup_AgeCheck_Failed | 성인 아님
블랙리스트 | Signup_PhoneBlacklist_Failed | 전화번호 제한
지역선택 진입 | Signup_Route_Entered | 정상 진입 유저
공통 에러 | Signup_Error | 디버깅용

####  지역 및 대학 선택
지역 선택 | Signup_area | 지역 선택 성공
대학 선택 | Signup_university | 대학 선택 성공

#### 상세 정보 입력
대학 상세 정보 입력 | Singup_university_details" | 상세 정보 입력 성공

#### 프로필 사진 
1번 프로필 사진 | "Signup_profile_image_1" | 1번 프로필 사진 클릭
2번 프로필 사진 | "Signup_profile_image_2" | 2번 프로필 사진 클릭
3번 프로필 사진 | "Signup_profile_image_3" | 3번 프로필 사진 클릭
프로필 사진 | Signup_profile_image | 프로필 사진 입력 성공
프로필 사진 실패 | Signup_profile_image_error | 프로필 사진 입력 실패 


#### 성공 안내 페이지
이상형 찾으러 가기 버튼 |completion_button_click | 회원가입 신청 후 하단 버튼 클릭

- 위 track의 내용들에는 사용자가 그 과정에서 어떤 정보들을 입력했는지 혹은 어떤 정보를 가지고 있는지와 에러의 경우 에러 메세지를 이벤트 프로퍼티에 입력해놨습니다.
- 다만 해당 작업 특성 상 실제 데이터를 수집하는 과정에서 니즈에 맞게 추후 지속적인 수정이 필요할 것으로 생각됩니다.
- 마지막으로 회원가입 뿐만 아니라 서비스 전반적으로 track 과정을 빠르게 추가해나가는 것이 좋을 것 같아요.

### 프로필 사진 확장자 안내 (추가작업)
사용자가 png, jpeg, jpg 가 아닌 다른 확장자로 사진을 업로드 했을 때 프론트엔드에서 Alert를 사용해 확장자 형식 안내를 추가했습니다
방식은 사용자가 업로드한 사진의 확장자를 pop 함수를 사용해 추출한 뒤 includes로 검사하는 간단한 방식을 사용하였습니다.





