### PR TITLE
Feat: 이상형 및 프로필 입력과 결제 부분 track 추가

### DIFF
--- a/app/home/index.tsx
+++ b/app/home/index.tsx
@@ -28,7 +28,6 @@ import { Image } from "expo-image";
 import { Link, router, useFocusEffect } from "expo-router";
 import { useCallback, useEffect, useState } from "react";
 import { Platform, ScrollView, TouchableOpacity, View } from "react-native";
-import {ImageResource} from "@ui/image-resource";
 
 const { ui, queries, hooks } = Home;
 const {
@@ -61,8 +60,8 @@ const HomeScreen = () => {
   const onScrollStateChange = (bool: boolean) => {
     setSlideScrolling(bool);
   };
-  const handleNavigateGemStore = () => {
-    router.navigate("/purchase/gem-store");
+  const handleNavigateToRematch = () => {
+    router.navigate("/purchase/tickets/rematch");
   };
 
   const onClickAlert = (notification: Notification) => {
@@ -111,9 +110,12 @@ const HomeScreen = () => {
         rightContent={
           <TouchableOpacity
             activeOpacity={0.8}
-            onPress={handleNavigateGemStore}
+            onPress={handleNavigateToRematch}
           >
-            <ImageResource resource={ImageResources.GEM} width={40} height={40}  />
+            <Image
+              source={require("@assets/images/ticket.png")}
+              style={{ width: 40, height: 40 }}
+            />
           </TouchableOpacity>
         }
       />

--- a/app/interest/age.tsx
+++ b/app/interest/age.tsx
@@ -6,6 +6,7 @@ import Layout from "@/src/features/layout";
 import Loading from "@/src/features/loading";
 import { environmentStrategy, platform } from "@/src/shared/libs";
 import { PalePurpleGradient } from "@/src/shared/ui";
+import { track } from "@amplitude/analytics-react-native";
 import Interest from "@features/interest";
 import { Text } from "@shared/ui";
 import { router, useFocusEffect } from "expo-router";
@@ -63,6 +64,11 @@ export default function AgeSelectionScreen() {
     useCallback(() => updateStep(InterestSteps.AGE), [updateStep])
   );
 
+  const onNext = () => {
+    track("Interest_Age");
+    router.push("/interest/like-mbti");
+  };
+
   if (optionsLoading) {
     return <Loading.Page title="나이대 선호도를 불러오고 있어요" />;
   }
@@ -94,7 +100,7 @@ export default function AgeSelectionScreen() {
 
         <Layout.TwoButtons
           disabledNext={!age}
-          onClickNext={() => router.push("/interest/like-mbti")}
+          onClickNext={onNext}
           onClickPrevious={() => {
             router.navigate("/interest");
           }}

--- a/app/interest/bad-mbti.tsx
+++ b/app/interest/bad-mbti.tsx
@@ -4,6 +4,7 @@ import Layout from "@/src/features/layout";
 import { useMbti } from "@/src/features/mypage/hooks";
 import { PalePurpleGradient, Text } from "@/src/shared/ui";
 import { MbtiSelector } from "@/src/widgets/mbti-selector";
+import { track } from "@amplitude/analytics-react-native";
 import { useFocusEffect, useRouter } from "expo-router";
 import React, { useCallback, useState } from "react";
 import { Image, StyleSheet, View } from "react-native";
@@ -32,6 +33,11 @@ function BadMbti() {
     return "다음으로";
   })();
 
+  const onNext = () => {
+    track("Interest_hateMbti");
+    router.push("/interest/personality");
+  };
+
   return (
     <Layout.Default>
       <PalePurpleGradient />
@@ -57,7 +63,7 @@ function BadMbti() {
           content={{
             next: nextMessage,
           }}
-          onClickNext={() => router.push("/interest/personality")}
+          onClickNext={onNext}
           onClickPrevious={() => router.navigate("/interest/like-mbti")}
         />
       </View>

--- a/app/interest/done.tsx
+++ b/app/interest/done.tsx
@@ -3,6 +3,7 @@ import { useInterestForm } from "@/src/features/interest/hooks";
 import Layout from "@/src/features/layout";
 import { Button, PalePurpleGradient, Text } from "@/src/shared/ui";
 import { IconWrapper } from "@/src/shared/ui/icons";
+import { track } from "@amplitude/analytics-react-native";
 import { useAuth } from "@features/auth";
 import { useQueryClient } from "@tanstack/react-query";
 import { Image } from "expo-image";
@@ -58,6 +59,7 @@ export default function InterestDoneScreen() {
             flex="flex-1"
             variant="primary"
             onPress={() => {
+              track("Interest_Done");
               clear();
               router.push("/home");
             }}

--- a/app/interest/drinking.tsx
+++ b/app/interest/drinking.tsx
@@ -3,6 +3,7 @@ import type { Preferences } from "@/src/features/interest/api";
 import Loading from "@/src/features/loading";
 import Tooltip from "@/src/shared/ui/tooltip";
 import { Selector } from "@/src/widgets/selector";
+import { track } from "@amplitude/analytics-react-native";
 import Interest from "@features/interest";
 import Layout from "@features/layout";
 import { PalePurpleGradient, StepSlider, Text } from "@shared/ui";
@@ -97,6 +98,7 @@ export default function DrinkingSelectionScreen() {
     if (!drinking) {
       updateForm("drinking", preferences.options[currentIndex]);
     }
+    track("Interest_Drinking");
     router.push("/interest/smoking");
   };
 

--- a/app/interest/index.tsx
+++ b/app/interest/index.tsx
@@ -3,6 +3,7 @@ import Layout from "@/src/features/layout";
 import { useModal } from "@/src/shared/hooks/use-modal";
 import { PalePurpleGradient, Text } from "@/src/shared/ui";
 import { IconWrapper } from "@/src/shared/ui/icons";
+import { track } from "@amplitude/analytics-react-native";
 import SmallTitle from "@assets/icons/small-title.svg";
 import { router } from "expo-router";
 import { Image, StyleSheet, View } from "react-native";
@@ -41,6 +42,11 @@ export default function InterestIntroScreen() {
       },
     });
 
+  const onNext = () => {
+    track("Interest_Intro");
+    router.push("/interest/age");
+  };
+
   return (
     <Layout.Default>
       <View style={styles.contentContainer}>
@@ -76,7 +82,7 @@ export default function InterestIntroScreen() {
         </View>
 
         <Layout.TwoButtons
-          onClickNext={() => router.push("/interest/age")}
+          onClickNext={onNext}
           disabledNext={false}
           onClickPrevious={showPreviousModal}
           content={{

--- a/app/interest/like-mbti.tsx
+++ b/app/interest/like-mbti.tsx
@@ -4,6 +4,7 @@ import Layout from "@/src/features/layout";
 import { useMbti } from "@/src/features/mypage/hooks";
 import { PalePurpleGradient, Text } from "@/src/shared/ui";
 import { MbtiSelector } from "@/src/widgets/mbti-selector";
+import { track } from "@amplitude/analytics-react-native";
 import { useFocusEffect, useRouter } from "expo-router";
 import React, { useCallback, useState } from "react";
 import { Image, StyleSheet, View } from "react-native";
@@ -23,6 +24,11 @@ function LikeMbti() {
   );
   const onUpdateMbti = (mbti: string) => {
     updateForm("goodMbti", mbti);
+  };
+
+  const onNext = () => {
+    track("Interest_likeMbti");
+    router.push("/interest/bad-mbti");
   };
 
   const nextMessage = (() => {
@@ -57,7 +63,7 @@ function LikeMbti() {
           content={{
             next: nextMessage,
           }}
-          onClickNext={() => router.push("/interest/bad-mbti")}
+          onClickNext={onNext}
           onClickPrevious={() => router.navigate("/interest/age")}
         />
       </View>

--- a/app/interest/personality.tsx
+++ b/app/interest/personality.tsx
@@ -2,6 +2,7 @@ import type { Preferences } from "@/src/features/interest/api";
 import Layout from "@/src/features/layout";
 import Loading from "@/src/features/loading";
 import { ChipSelector } from "@/src/widgets";
+import { track } from "@amplitude/analytics-react-native";
 import Interest from "@features/interest";
 import { PalePurpleGradient, Text } from "@shared/ui";
 import { router, useFocusEffect } from "expo-router";
@@ -41,6 +42,11 @@ export default function PersonalitySelectionScreen() {
     }
     return "다음으로";
   })();
+
+  const onNext = () => {
+    track("Interest_Personality");
+    router.push("/interest/drinking");
+  };
 
   useFocusEffect(
     useCallback(() => updateStep(InterestSteps.PERSONALITY), [updateStep])
@@ -90,7 +96,7 @@ export default function PersonalitySelectionScreen() {
         content={{
           next: nextMessage,
         }}
-        onClickNext={() => router.push("/interest/drinking")}
+        onClickNext={onNext}
         onClickPrevious={() => router.navigate("/interest/bad-mbti")}
       />
     </Layout.Default>

--- a/app/interest/smoking.tsx
+++ b/app/interest/smoking.tsx
@@ -3,6 +3,7 @@ import Loading from "@/src/features/loading";
 import Tooltip from "@/src/shared/ui/tooltip";
 import { PreferenceOption } from "@/src/types/user";
 import { Selector } from "@/src/widgets/selector";
+import { track } from "@amplitude/analytics-react-native";
 import Interest from "@features/interest";
 import Layout from "@features/layout";
 import { PalePurpleGradient, StepSlider, Text } from "@shared/ui";
@@ -82,6 +83,7 @@ export default function SmokingSelectionScreen() {
     if (!smoking) {
       updateForm("smoking", preferences.options[currentIndex]);
     }
+    track("Interest_Smoking");
     router.push("/interest/tattoo");
   };
   useFocusEffect(

--- a/app/interest/tattoo.tsx
+++ b/app/interest/tattoo.tsx
@@ -7,6 +7,7 @@ import { useModal } from "@/src/shared/hooks/use-modal";
 import { tryCatch } from "@/src/shared/libs";
 import Tooltip from "@/src/shared/ui/tooltip";
 import { Selector } from "@/src/widgets/selector";
+import { track } from "@amplitude/analytics-react-native";
 import Interest from "@features/interest";
 import Layout from "@features/layout";
 import { PalePurpleGradient, StepSlider, Text } from "@shared/ui";
@@ -103,6 +104,7 @@ export default function TattooSelectionScreen() {
         await queryClient.invalidateQueries({
           queryKey: ["check-preference-fill"],
         });
+        track("Interest_Tattoo");
         router.navigate("/interest/done");
         setFormSubmitLoading(false);
       },

--- a/app/my-info/dating-style.tsx
+++ b/app/my-info/dating-style.tsx
@@ -6,6 +6,7 @@ import type { Preferences } from "@/src/features/my-info/api";
 import { ImageResources } from "@/src/shared/libs";
 import { Divider, PalePurpleGradient, Text } from "@/src/shared/ui";
 import { ChipSelector, StepIndicator } from "@/src/widgets";
+import { track } from "@amplitude/analytics-react-native";
 import { router, useFocusEffect } from "expo-router";
 import { useCallback } from "react";
 import { Image, StyleSheet, View } from "react-native";
@@ -57,6 +58,7 @@ export default function DatingStyleSelectionScreen() {
   );
 
   const handleNextButton = () => {
+    track("Profile_DatingStyle");
     router.push("/my-info/drinking");
   };
 

--- a/app/my-info/done.tsx
+++ b/app/my-info/done.tsx
@@ -3,6 +3,7 @@ import { useInterestForm } from "@/src/features/interest/hooks";
 import Layout from "@/src/features/layout";
 import { Button, PalePurpleGradient, Text } from "@/src/shared/ui";
 import { IconWrapper } from "@/src/shared/ui/icons";
+import { track } from "@amplitude/analytics-react-native";
 import { useAuth } from "@features/auth";
 import { useQueryClient } from "@tanstack/react-query";
 import { Image } from "expo-image";
@@ -59,6 +60,7 @@ export default function InterestDoneScreen() {
             variant="primary"
             size="md"
             onPress={() => {
+              track("Profile_Done");
               clear();
               router.push("/home");
             }}

--- a/app/my-info/drinking.tsx
+++ b/app/my-info/drinking.tsx
@@ -3,6 +3,7 @@ import Loading from "@/src/features/loading";
 import MyInfo from "@/src/features/my-info";
 import type { Preferences } from "@/src/features/my-info/api";
 import Tooltip from "@/src/shared/ui/tooltip";
+import { track } from "@amplitude/analytics-react-native";
 import Interest from "@features/interest";
 import Layout from "@features/layout";
 import { PalePurpleGradient, StepSlider, Text } from "@shared/ui";
@@ -90,6 +91,7 @@ export default function DrinkingSelectionScreen() {
     if (!drinking) {
       updateForm("drinking", preferences.options[currentIndex]);
     }
+    track("Profile_Drinking");
     router.push("/my-info/smoking");
   };
 

--- a/app/my-info/index.tsx
+++ b/app/my-info/index.tsx
@@ -3,6 +3,7 @@ import Layout from "@/src/features/layout";
 import { useModal } from "@/src/shared/hooks/use-modal";
 import { PalePurpleGradient, Text } from "@/src/shared/ui";
 import { IconWrapper } from "@/src/shared/ui/icons";
+import { track } from "@amplitude/analytics-react-native";
 import SmallTitle from "@assets/icons/small-title.svg";
 import { router } from "expo-router";
 import { Image, StyleSheet, View } from "react-native";
@@ -41,6 +42,11 @@ export default function InterestIntroScreen() {
       },
     });
 
+  const onNext = () => {
+    track("Profile_Intro");
+    router.push("/my-info/interest");
+  };
+
   return (
     <Layout.Default>
       <View style={styles.contentContainer}>
@@ -76,7 +82,7 @@ export default function InterestIntroScreen() {
         </View>
 
         <Layout.TwoButtons
-          onClickNext={() => router.push("/my-info/interest")}
+          onClickNext={onNext}
           disabledNext={false}
           onClickPrevious={showPreviousModal}
           content={{

--- a/app/my-info/interest.tsx
+++ b/app/my-info/interest.tsx
@@ -2,6 +2,7 @@ import Layout from "@/src/features/layout";
 import Loading from "@/src/features/loading";
 import MyInfo from "@/src/features/my-info";
 import { ChipSelector, StepIndicator } from "@/src/widgets";
+import { track } from "@amplitude/analytics-react-native";
 import { Divider, PalePurpleGradient, Text } from "@shared/ui";
 import { router, useFocusEffect } from "expo-router";
 import { useCallback } from "react";
@@ -47,6 +48,11 @@ export default function InterestSelectionScreen() {
   useFocusEffect(
     useCallback(() => updateStep(MyInfoSteps.INTEREST), [updateStep])
   );
+
+  const onNext = () => {
+    track("Profile_Interest");
+    router.push("/my-info/mbti");
+  };
 
   return (
     <Layout.Default>
@@ -100,7 +106,7 @@ export default function InterestSelectionScreen() {
         content={{
           next: nextMessage,
         }}
-        onClickNext={() => router.push("/my-info/mbti")}
+        onClickNext={onNext}
         onClickPrevious={() => router.navigate("/my-info")}
       />
     </Layout.Default>

--- a/app/my-info/mbti.tsx
+++ b/app/my-info/mbti.tsx
@@ -3,6 +3,7 @@ import MyInfo from "@/src/features/my-info";
 import { useMbti } from "@/src/features/mypage/hooks";
 import { PalePurpleGradient, Text } from "@/src/shared/ui";
 import { MbtiSelector } from "@/src/widgets/mbti-selector";
+import { track } from "@amplitude/analytics-react-native";
 import { useFocusEffect, useRouter } from "expo-router";
 import React, { useCallback } from "react";
 import { Image, StyleSheet, View } from "react-native";
@@ -24,6 +25,7 @@ function MbtiSectionScreen() {
 
   const handleNextButton = () => {
     updateMbti(mbti as string);
+    track("Profile_Mbti", { mbti: mbti });
     router.push("/my-info/personality");
   };
 

--- a/app/my-info/personality.tsx
+++ b/app/my-info/personality.tsx
@@ -3,6 +3,7 @@ import Loading from "@/src/features/loading";
 import MyInfo from "@/src/features/my-info";
 import type { Preferences } from "@/src/features/my-info/api";
 import { ChipSelector, StepIndicator } from "@/src/widgets";
+import { track } from "@amplitude/analytics-react-native";
 import Interest from "@features/interest";
 import { Divider, PalePurpleGradient, Text } from "@shared/ui";
 import { router, useFocusEffect } from "expo-router";
@@ -42,6 +43,11 @@ export default function PersonalitySelectionScreen() {
     }
     return "다음으로";
   })();
+
+  const onNext = () => {
+    track("Profile_personality");
+    router.push("/my-info/dating-style");
+  };
 
   useFocusEffect(
     useCallback(() => updateStep(MyInfoSteps.PERSONALITY), [updateStep])
@@ -91,7 +97,7 @@ export default function PersonalitySelectionScreen() {
         content={{
           next: nextMessage,
         }}
-        onClickNext={() => router.push("/my-info/dating-style")}
+        onClickNext={onNext}
         onClickPrevious={() => router.navigate("/my-info/mbti")}
       />
     </Layout.Default>

--- a/app/my-info/smoking.tsx
+++ b/app/my-info/smoking.tsx
@@ -2,6 +2,7 @@ import Loading from "@/src/features/loading";
 import MyInfo from "@/src/features/my-info";
 import type { Preferences } from "@/src/features/my-info/api";
 import Tooltip from "@/src/shared/ui/tooltip";
+import { track } from "@amplitude/analytics-react-native";
 
 import Layout from "@features/layout";
 import { PalePurpleGradient, StepSlider, Text } from "@shared/ui";
@@ -72,6 +73,7 @@ export default function SmokingSelectionScreen() {
     if (!smoking) {
       updateForm("smoking", preferences.options[currentIndex]);
     }
+    track("Profile_Smoking");
     router.push("/my-info/tattoo");
   };
   useFocusEffect(

--- a/app/my-info/tattoo.tsx
+++ b/app/my-info/tattoo.tsx
@@ -7,6 +7,7 @@ import { queryClient } from "@/src/shared/config/query";
 import { useModal } from "@/src/shared/hooks/use-modal";
 import { tryCatch } from "@/src/shared/libs";
 import Tooltip from "@/src/shared/ui/tooltip";
+import { track } from "@amplitude/analytics-react-native";
 import Layout from "@features/layout";
 import { PalePurpleGradient, StepSlider, Text } from "@shared/ui";
 import { router, useFocusEffect } from "expo-router";
@@ -95,6 +96,7 @@ export default function TattooSelectionScreen() {
         await queryClient.invalidateQueries({
           queryKey: ["preference-self"],
         });
+        track("Profile_Tattoo");
         router.navigate("/my-info/done");
         setFormSubmitLoading(false);
       },

--- a/app/purchase/tickets/rematch.tsx
+++ b/app/purchase/tickets/rematch.tsx
@@ -4,6 +4,7 @@ import { RematchingTicket } from "@/src/features/payment/ui/rematching-ticket";
 import { useModal } from "@/src/shared/hooks/use-modal";
 import { Ticket, TicketDetails } from "@/src/widgets";
 import { Selector } from "@/src/widgets/selector";
+import { track } from "@amplitude/analytics-react-native";
 import Layout from "@features/layout";
 import Payment from "@features/payment";
 import type { PortOneController } from "@portone/react-native-sdk";
@@ -42,6 +43,7 @@ export default function RematchingTicketSellingScreen() {
       setTotalPrice(metadata.totalPrice);
       setProductCount(metadata.count);
       setShowPayment(true);
+      track("Purchase_Count", { count: metadata.count });
     } catch (error) {
       Alert.alert("오류", "결제 처리 중 오류가 발생했습니다.");
       setShowPayment(false);
@@ -64,6 +66,7 @@ export default function RematchingTicketSellingScreen() {
 
   const onCompletePayment = (result: PaymentResponse) => {
     setShowPayment(false);
+    track("Purchase_Done");
     handlePaymentComplete(result, {
       productCount,
       onError,

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
 			"name": "sometimes",
 			"version": "1.0.0",
 			"dependencies": {
+				"@amplitude/analytics-react-native": "^1.5.0",
 				"@babel/plugin-proposal-export-namespace-from": "^7.18.9",
 				"@expo/config-plugins": "^10.0.2",
 				"@expo/vector-icons": "^14.0.2",
@@ -130,6 +131,64 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/@amplitude/analytics-connector": {
+			"version": "1.6.4",
+			"resolved": "https://registry.npmjs.org/@amplitude/analytics-connector/-/analytics-connector-1.6.4.tgz",
+			"integrity": "sha512-SpIv0IQMNIq6SH3UqFGiaZyGSc7PBZwRdq7lvP0pBxW8i4Ny+8zwI0pV+VMfMHQwWY3wdIbWw5WQphNjpdq1/Q=="
+		},
+		"node_modules/@amplitude/analytics-core": {
+			"version": "2.19.0",
+			"resolved": "https://registry.npmjs.org/@amplitude/analytics-core/-/analytics-core-2.19.0.tgz",
+			"integrity": "sha512-G1RwMOjkEV1Ccx7vU3CsPFt0w5yNFlVFNpCKaWO7zVbsqA9PRljPXj3fKXPrto6s2vKTXmuGG5NuWM/iSVfBwA==",
+			"dependencies": {
+				"@amplitude/analytics-connector": "^1.6.4",
+				"tslib": "^2.4.1"
+			}
+		},
+		"node_modules/@amplitude/analytics-react-native": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/@amplitude/analytics-react-native/-/analytics-react-native-1.5.0.tgz",
+			"integrity": "sha512-Mj7utntebyzpij23i+/mu5KIsz/NuKXUt8GbtYFzstMamxH4JetQ264KQV/QpUCBQZWwgPfiJ3XTs+Zb9Zow1g==",
+			"dependencies": {
+				"@amplitude/analytics-core": "^2.19.0",
+				"@amplitude/ua-parser-js": "^0.7.31",
+				"@react-native-async-storage/async-storage": "^1.17.11",
+				"tslib": "^2.4.1"
+			},
+			"peerDependencies": {
+				"react": "*",
+				"react-native": "*"
+			}
+		},
+		"node_modules/@amplitude/analytics-react-native/node_modules/@react-native-async-storage/async-storage": {
+			"version": "1.24.0",
+			"resolved": "https://registry.npmjs.org/@react-native-async-storage/async-storage/-/async-storage-1.24.0.tgz",
+			"integrity": "sha512-W4/vbwUOYOjco0x3toB8QCr7EjIP6nE9G7o8PMguvvjYT5Awg09lyV4enACRx4s++PPulBiBSjL0KTFx2u0Z/g==",
+			"dependencies": {
+				"merge-options": "^3.0.4"
+			},
+			"peerDependencies": {
+				"react-native": "^0.0.0-0 || >=0.60 <1.0"
+			}
+		},
+		"node_modules/@amplitude/ua-parser-js": {
+			"version": "0.7.33",
+			"resolved": "https://registry.npmjs.org/@amplitude/ua-parser-js/-/ua-parser-js-0.7.33.tgz",
+			"integrity": "sha512-wKEtVR4vXuPT9cVEIJkYWnlF++Gx3BdLatPBM+SZ1ztVIvnhdGBZR/mn9x/PzyrMcRlZmyi6L56I2J3doVBnjA==",
+			"funding": [
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/ua-parser-js"
+				},
+				{
+					"type": "paypal",
+					"url": "https://paypal.me/faisalman"
+				}
+			],
+			"engines": {
+				"node": "*"
 			}
 		},
 		"node_modules/@ampproject/remapping": {

--- a/src/features/home/hooks/use-redirect-preferences.tsx
+++ b/src/features/home/hooks/use-redirect-preferences.tsx
@@ -1,11 +1,12 @@
-import {useStorage} from "@/src/shared/hooks/use-storage";
-import {useCheckPreferenceFillQuery} from "../queries";
-import {useCallback, useEffect} from "react";
-import {useModal} from "@/src/shared/hooks/use-modal";
-import {View} from "react-native";
-import {Text} from "@/src/shared/ui";
-import {dayUtils} from "@/src/shared/libs";
-import {router} from "expo-router";
+import { useModal } from "@/src/shared/hooks/use-modal";
+import { useStorage } from "@/src/shared/hooks/use-storage";
+import { dayUtils } from "@/src/shared/libs";
+import { Text } from "@/src/shared/ui";
+import { track } from "@amplitude/analytics-react-native";
+import { router } from "expo-router";
+import { useCallback, useEffect } from "react";
+import { View } from "react-native";
+import { useCheckPreferenceFillQuery } from "../queries";
 
 type CheckPreferences = {
   isLater: boolean;
@@ -13,32 +14,44 @@ type CheckPreferences = {
 };
 
 export const useRedirectPreferences = () => {
-  const {data: isPreferenceFill, refetch, isLoading} = useCheckPreferenceFillQuery();
-  const {value: latest, setValue, loading} = useStorage<CheckPreferences>({
-    key: 'redirect-preferences',
+  const {
+    data: isPreferenceFill,
+    refetch,
+    isLoading,
+  } = useCheckPreferenceFillQuery();
+  const {
+    value: latest,
+    setValue,
+    loading,
+  } = useStorage<CheckPreferences>({
+    key: "redirect-preferences",
   });
-  const {showModal} = useModal();
+  const { showModal } = useModal();
 
-  const confirm = useCallback(() =>
-      setValue({
-        isLater: true,
-        latestDate: dayUtils.create().format('YYYY-MM-DD HH:mm:ss'),
-      }), [setValue]);
+  const confirm = useCallback(() => {
+    track("Interest_Hold");
+    setValue({
+      isLater: true,
+      latestDate: dayUtils.create().format("YYYY-MM-DD HH:mm:ss"),
+    });
+  }, [setValue]);
 
   const onRedirect = useCallback(() => {
     confirm();
-    router.navigate('/interest');
+    track("Interest_Started", { type: "modal" });
+    router.navigate("/interest");
   }, [confirm]);
 
-  const showPreferenceModal = useCallback((reason: string) => {
-    console.log('Showing modal -', reason);
-    showModal({
-      customTitle: (
+  const showPreferenceModal = useCallback(
+    (reason: string) => {
+      console.log("Showing modal -", reason);
+      showModal({
+        customTitle: (
           <Text size="md" weight="bold" textColor="black" className="mb-2">
             회원님의 이상형 정보가 없어요!
           </Text>
-      ),
-      children: (
+        ),
+        children: (
           <View className="flex flex-col">
             <Text size="sm" textColor="black">
               나에게 맞는 연인 매칭을 위해
@@ -47,38 +60,51 @@ export const useRedirectPreferences = () => {
               회원님의 이상형 정보를 등록하시겠어요?
             </Text>
           </View>
-      ),
-      primaryButton: {
-        text: '등록할게요!',
-        onClick: onRedirect,
-      },
-      secondaryButton: {
-        text: '나중에 할게요',
-        onClick: confirm,
-      },
-    });
-  }, [showModal, onRedirect, confirm]);
+        ),
+        primaryButton: {
+          text: "등록할게요!",
+          onClick: onRedirect,
+        },
+        secondaryButton: {
+          text: "나중에 할게요",
+          onClick: confirm,
+        },
+      });
+    },
+    [showModal, onRedirect, confirm]
+  );
 
   useEffect(() => {
     // 로딩 중이거나 이상형이 이미 등록된 경우 모달을 보여주지 않음
     if (loading || isLoading || isPreferenceFill) {
-      console.log('Modal not shown - loading or preference filled:', {loading, isLoading, isPreferenceFill});
+      console.log("Modal not shown - loading or preference filled:", {
+        loading,
+        isLoading,
+        isPreferenceFill,
+      });
       return;
     }
 
     if (isPreferenceFill === false) {
       if (!latest || !latest.isLater) {
-        showPreferenceModal('no preference and no later flag');
+        showPreferenceModal("no preference and no later flag");
         return;
       }
 
       const now = dayUtils.create();
-      const diff = now.diff(latest?.latestDate, 'day');
+      const diff = now.diff(latest?.latestDate, "day");
       if (diff > 1) {
-        showPreferenceModal('later flag expired');
+        showPreferenceModal("later flag expired");
       }
     }
-  }, [loading, isLoading, isPreferenceFill, latest?.isLater, latest?.latestDate, showPreferenceModal]);
+  }, [
+    loading,
+    isLoading,
+    isPreferenceFill,
+    latest?.isLater,
+    latest?.latestDate,
+    showPreferenceModal,
+  ]);
 
   return {
     ...latest,

--- a/src/features/home/ui/home-info/home-info-section.tsx
+++ b/src/features/home/ui/home-info/home-info-section.tsx
@@ -1,3 +1,4 @@
+import { track } from "@amplitude/analytics-react-native";
 import { useRouter } from "expo-router";
 import React from "react";
 import { StyleSheet, View } from "react-native";
@@ -13,12 +14,21 @@ function HomeInfoSection() {
   const { isPreferenceFill } = useRedirectPreferences();
   const { data: preferencesSelf } = usePreferenceSelfQuery();
   const router = useRouter();
+  const handleClickButton = (to: "my-info" | "interest") => {
+    if (to === "my-info") {
+      track("Profile_Started");
+      router.navigate("/my-info");
+    } else {
+      track("Interest_Started", { type: "home" });
+      router.navigate("/interest");
+    }
+  };
   return (
     <View style={styles.container}>
       <HomeInfoCard
         buttonMessage={preferencesSelf?.length !== 0 ? "완료" : "입력 하기"}
         buttonDisabled={preferencesSelf?.length !== 0}
-        onClick={() => router.navigate("/my-info")}
+        onClick={() => handleClickButton("my-info")}
         imageUri={require("@assets/images/my-info.png")}
         title={"나의 정보"}
         description="성격, 취미, 연애 스타일 등"
@@ -26,7 +36,7 @@ function HomeInfoSection() {
       <HomeInfoCard
         buttonMessage={isPreferenceFill ? "완료" : "입력 하기"}
         buttonDisabled={isPreferenceFill}
-        onClick={() => router.navigate("/interest")}
+        onClick={() => handleClickButton("interest")}
         imageUri={require("@assets/images/interest-info.png")}
         title={"이상형 정보"}
         description="선호하는 성격, 취향, 음주 등"


### PR DESCRIPTION
## 회원가입 후 첫 화면

![image.png](attachment:7a00a8ef-3387-4170-9a16-90a01e7f11de:image.png)

### 진입점

- 모달의 “나중에 할게요”와 “등록할게요!”
- 홈화면의 나의 정보 “입력 하기”와 이상형 정보 “입력 하기”
    - 어떻게 구분할까?
    - [나중에 할게요] 와 [등록할게요! and 입력 하기] 는 동일한 성격
    이벤트 프로퍼티로 구분하자

- 군필 여부는 두 플로우 모두 의도적 제외  (이탈률을 측정하기 위함인데 군필 여부에서 이탈률이 높아지진 않을 것 같고 이탈률 통계 잡을 때 괜히 헷갈릴 수도 있음)
- 이벤트 프로퍼티에 유저가 입력할 정보를 담을 필요는 없어보임
- 어떤 mbti의 유저가 이탈률이 높을까?

이상형 입력 플로우 

입력하기 | Interset_Started | 이상형 정보 입력 시작 {type: modal | home}

입력 보류 | Interest_Hold | 이상형 정보 입력 보류

인트로  | Interest_Intro | 이상형 정보 인트로 화면

나이 선택 | Interest_Age | 이상형 정보 연령대 선택

선호 mbti 선택 | Interest_likeMbti | 이상형 정보 mbti 선택

비선호 mbti 선택 | Interest_hateMbti | 이상형 정보 비선호 mbti 선택

성격 선택 | Interest_Personality | 이상형 정보 선호 성격 선택

음주 여부 선택 | Interest_Drinking | 이상형 정보 음주 여부 선택 

흡연 여부 선택 | Interest_Smoking | 이상형 정보 흡연 여부 선택

문신 여부 선택 | Interest_Tattoo | 이상형 정보 문신 여부 선택

입력 완료 | Interest_Done | 이상형 정보 입력 완료

나의 정보 입력 플로우

입력하기 | Profile_Started | 프로필 정보 입력 시작

인트로  | Profile_Intro | 프로필 정보 인트로 화면

취미 선택 | Profile_Interest | 프로필 정보 연령대 선택

 mbti 선택 | Profile_Mbti | 프로필 정보 mbti 선택

성격 선택 | Profile_personality | 프로필 정보 성격 선택

연애 스타일 선택 | Profile_DatingStyle | 프로필 정보 연애 스타일 선택

음주 여부 선택 | Profile_Drinking | 프로필 정보 음주 여부 선택 

흡연 여부 선택 | Profile_Smoking | 프로필 정보 흡연 여부 선택

문신 여부 선택 | Profile_Tattoo | 프로필 정보 문신 여부 선택

입력 완료 | Profile_Done | 프로필 정보 입력 완료


결제 진입점

재매칭을 위한 진입

- 재매칭권 사용하기

이전매칭 

- 이전매칭 잠금 풀기

모호한 부분

- 홈화면 상단

결제 플로우 
결제 진입 | Purchase_Started | 결제 진입 {type: “이전 매칭 잠금” | “재매칭” | “알 수 없음”}

결제 클릭 | Purchase_Count | 결제 클릭 {count: number}

결제 완료 | Purchase_Done | 결제 완료