### PR TITLE
feat: 커뮤니티 게시글, 댓글에 링크 탐지 기능 추가

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "sometimes",
     "slug": "sometimes",
-    "version": "1.6.2",
+    "version": "1.6.3",
     "orientation": "portrait",
     "icon": "./assets/icons/app.png",
     "scheme": "myapp",

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "sometimes",
     "slug": "sometimes",
-    "version": "1.6.1",
+    "version": "1.6.2",
     "orientation": "portrait",
     "icon": "./assets/icons/app.png",
     "scheme": "myapp",

--- a/src/features/community/ui/article-detail/article-detail-comment.tsx
+++ b/src/features/community/ui/article-detail/article-detail-comment.tsx
@@ -2,7 +2,7 @@ import colors from "@/src/shared/constants/colors";
 import { useBoolean } from "@/src/shared/hooks/use-boolean";
 import { dayUtils } from "@/src/shared/libs";
 import type { UniversityName } from "@/src/shared/libs/univ";
-import { Divider, Show, Text } from "@/src/shared/ui";
+import { Divider, LinkifiedText, Show, Text } from "@/src/shared/ui";
 import { Dropdown, type DropdownItem } from "@/src/shared/ui/dropdown";
 import type React from "react";
 import { useMemo } from "react";
@@ -82,7 +82,7 @@ export const ArticleDetailComment: React.FC<ArticleDetailCommentProps> = ({
           paddingRight: 16,
         }}
       >
-        <Text
+        <LinkifiedText
           className="text-[14px] flex-1"
           textColor="black"
           style={{
@@ -92,7 +92,7 @@ export const ArticleDetailComment: React.FC<ArticleDetailCommentProps> = ({
           }}
         >
           {comment.content}
-        </Text>
+        </LinkifiedText>
       </View>
     </View>
   );

--- a/src/features/community/ui/article-detail/article-detail.tsx
+++ b/src/features/community/ui/article-detail/article-detail.tsx
@@ -9,7 +9,7 @@ import {
 import { QUERY_KEYS } from "@/src/features/community/queries/keys";
 import Interaction from "@/src/features/community/ui/article/interaction-nav";
 import Loading from "@/src/features/loading";
-import { Text } from "@/src/shared/ui";
+import { LinkifiedText, Text } from "@/src/shared/ui";
 import { dayUtils, tryCatch } from "@shared/libs";
 import type { UniversityName } from "@shared/libs";
 import { useQueryClient } from "@tanstack/react-query";
@@ -222,9 +222,9 @@ export const ArticleDetail = ({ article }: { article: Article }) => {
             {dayUtils.formatRelativeTime(article.createdAt)}
           </Text>
         </View>
-        <Text className="mb-4 text-[14px] mx-[8px] leading-5" textColor="black">
+        <LinkifiedText className="mb-4 text-[14px] mx-[8px] leading-5" textColor="black">
           {article.content}
-        </Text>
+        </LinkifiedText>
         <View className="w-full mt-[10px]">
           <View className="flex-row items-center justify-around gap-4 pb-[10px]">
             <Interaction.Like

--- a/src/features/community/ui/article/index.tsx
+++ b/src/features/community/ui/article/index.tsx
@@ -1,26 +1,23 @@
-import ShieldNotSecuredIcon from "@/assets/icons/shield-not-secured.svg";
 import { useAuth } from "@/src/features/auth";
 import { useBoolean } from "@/src/shared/hooks/use-boolean";
 import {
   ImageResources,
   type UniversityName,
   dayUtils,
-  getUnivLogo,
 } from "@/src/shared/libs";
 import {
   Divider,
   Dropdown,
   type DropdownItem,
   ImageResource,
+  LinkifiedText,
   Show,
   Text,
-  dropdownStyles,
 } from "@/src/shared/ui";
-import { IconWrapper } from "@/src/shared/ui/icons";
 import { router } from "expo-router";
 import { useEffect } from "react";
-import { Image, TouchableOpacity, View } from "react-native";
-import { useCategory } from "../../hooks";
+import { TouchableOpacity, View } from "react-native";
+
 import type { Article as ArticleType } from "../../types";
 import { Comment } from "../comment";
 import { UserProfile } from "../user-profile";
@@ -47,10 +44,9 @@ export function Article({ data, onPress, onLike, onDelete }: ArticleItemProps) {
   } = useBoolean();
   const {
     value: isDropdownOpen,
-    toggle: toggleDropdown,
     setFalse: closeDropdown,
   } = useBoolean();
-  const { currentCategory } = useCategory();
+
 
   const isOwner = (() => {
     if (!my) return false;
@@ -104,7 +100,7 @@ export function Article({ data, onPress, onLike, onDelete }: ArticleItemProps) {
   useEffect(() => {
     setFalse();
     closeDropdown();
-  }, [currentCategory]);
+  }, [setFalse, closeDropdown]);
 
   return (
     <View className="w-full relative">
@@ -127,9 +123,14 @@ export function Article({ data, onPress, onLike, onDelete }: ArticleItemProps) {
             {dayUtils.formatRelativeTime(data.createdAt)}
           </Text>
         </View>
-        <Text size="sm" className="mb-4 mx-[8px] leading-5" textColor="black">
+        <LinkifiedText
+          size="sm"
+          className="mb-4 mx-[8px] leading-5"
+          textColor="black"
+          style={{ flexWrap: 'wrap', flexShrink: 1 }}
+        >
           {data.content}
-        </Text>
+        </LinkifiedText>
 
         <View className="flex-row items-center  mx-[8px]   justify-between">
           <Interaction.Like

--- a/src/features/community/ui/comment/index.tsx
+++ b/src/features/community/ui/comment/index.tsx
@@ -1,7 +1,7 @@
 import { View, Image, Platform } from "react-native";
 import type { Comment as CommentType } from "../../types";
 import { dayUtils, getUnivLogo, UniversityName } from "@/src/shared/libs";
-import { Text } from "@/src/shared/ui";
+import { LinkifiedText, Text } from "@/src/shared/ui";
 import { useState } from "react";
 
 type CommentProps = {
@@ -19,7 +19,7 @@ export const Comment = ({ data, className }: CommentProps) => {
         <Image
           source={{ uri: imageUri }}
           style={{ width: 36, height: 36 }}
-          onError={err => {
+          onError={() => {
             setImageUri(getUnivLogo(UniversityName.한밭대학교));
           }}
           className="rounded-full"
@@ -32,7 +32,7 @@ export const Comment = ({ data, className }: CommentProps) => {
             <Text size="sm" className="text-[#646464]">{dayUtils.formatRelativeTime(data.updatedAt)}</Text>
           </View>
           <View className="pt-1.5 flex-1">
-            <Text
+            <LinkifiedText
               size="sm"
               textColor="black"
               className="flex-1"
@@ -43,7 +43,7 @@ export const Comment = ({ data, className }: CommentProps) => {
               }}
             >
               {data.content}
-            </Text>
+            </LinkifiedText>
           </View>
       </View>
     </View>

--- a/src/shared/ui/index.tsx
+++ b/src/shared/ui/index.tsx
@@ -23,4 +23,5 @@ export * from './announce-card';
 export * from './business-info';
 export * from './carousel';
 export * from './text-area';
+export * from './linkified-text';
 

--- a/src/shared/ui/linkified-text/index.tsx
+++ b/src/shared/ui/linkified-text/index.tsx
@@ -1,0 +1,75 @@
+import type React from 'react';
+import { TouchableOpacity, Linking, Alert, View } from 'react-native';
+import { Text, type TextProps } from '../text';
+import { parseTextWithLinks } from '../../utils/link-utils';
+
+export interface LinkifiedTextProps extends Omit<TextProps, 'children'> {
+  children: string;
+  linkColor?: string;
+  onLinkPress?: (url: string) => void;
+}
+
+/**
+ * 텍스트에서 링크를 탐지하고 클릭 가능한 링크로 렌더링하는 컴포넌트
+ */
+export const LinkifiedText: React.FC<LinkifiedTextProps> = ({
+  children,
+  linkColor = '#8B5CF6',
+  onLinkPress,
+  ...textProps
+}) => {
+  const handleLinkPress = async (url: string) => {
+    if (onLinkPress) {
+      onLinkPress(url);
+      return;
+    }
+
+    try {
+      await Linking.openURL(url);
+    } catch (error) {
+      console.error('링크 열기 오류:', error);
+      Alert.alert('오류', '링크를 열 수 없습니다.');
+    }
+  };
+
+  const segments = parseTextWithLinks(children || '');
+
+  if (segments.length === 1 && segments[0].type === 'text') {
+    return <Text {...textProps}>{segments[0].content}</Text>;
+  }
+
+  return (
+    <View style={{ flexDirection: 'row', flexWrap: 'wrap', flex: 1 }}>
+      {segments.map((segment, index) => {
+        const key = `${segment.type}-${index}-${segment.content.slice(0, 10)}`;
+
+        if (segment.type === 'link') {
+          return (
+            <TouchableOpacity
+              key={key}
+              onPress={() => handleLinkPress(segment.content)}
+              activeOpacity={0.7}
+            >
+              <Text
+                {...textProps}
+                style={{
+                  ...textProps.style,
+                  color: linkColor,
+                  textDecorationLine: 'underline'
+                }}
+              >
+                {segment.content}
+              </Text>
+            </TouchableOpacity>
+          );
+        }
+
+        return (
+          <Text key={key} {...textProps}>
+            {segment.content}
+          </Text>
+        );
+      })}
+    </View>
+  );
+};

--- a/src/shared/utils/index.ts
+++ b/src/shared/utils/index.ts
@@ -1,2 +1,3 @@
 export * from './analytics';
 export * from './string-utils';
+export * from './link-utils';

--- a/src/shared/utils/link-utils.ts
+++ b/src/shared/utils/link-utils.ts
@@ -7,7 +7,7 @@ export interface TextSegment {
   content: string;
 }
 
-const URL_REGEX = /(https?:\/\/[^\s]+)/gi;
+const URL_REGEX = /(https:\/\/[^\s]+)/gi;
 
 /**
  * 텍스트에서 URL이 포함되어 있는지 확인

--- a/src/shared/utils/link-utils.ts
+++ b/src/shared/utils/link-utils.ts
@@ -1,0 +1,59 @@
+/**
+ * Link detection and parsing utilities
+ */
+
+export interface TextSegment {
+  type: 'text' | 'link';
+  content: string;
+}
+
+const URL_REGEX = /(https?:\/\/[^\s]+)/gi;
+
+/**
+ * 텍스트에서 URL이 포함되어 있는지 확인
+ */
+export function hasLinks(text: string): boolean {
+  return !!text && URL_REGEX.test(text);
+}
+
+/**
+ * 텍스트를 파싱하여 링크와 일반 텍스트로 분리
+ */
+export function parseTextWithLinks(text: string): TextSegment[] {
+  if (!text) return [{ type: 'text', content: text }];
+
+  const segments: TextSegment[] = [];
+  let lastIndex = 0;
+
+  URL_REGEX.lastIndex = 0;
+
+  let match: RegExpExecArray | null = URL_REGEX.exec(text);
+  while (match !== null) {
+    const matchStart = match.index;
+    const url = match[0];
+
+    if (matchStart > lastIndex) {
+      segments.push({
+        type: 'text',
+        content: text.slice(lastIndex, matchStart),
+      });
+    }
+
+    segments.push({
+      type: 'link',
+      content: url,
+    });
+
+    lastIndex = URL_REGEX.lastIndex;
+    match = URL_REGEX.exec(text);
+  }
+
+  if (lastIndex < text.length) {
+    segments.push({
+      type: 'text',
+      content: text.slice(lastIndex),
+    });
+  }
+
+  return segments.length > 0 ? segments : [{ type: 'text', content: text }];
+}


### PR DESCRIPTION
## 📝 변경 사항
커뮤니티 게시글과 댓글에서 HTTPS URL을 자동으로 탐지하여 클릭 가능한 하이퍼링크로 표시하는 기능을 추가했습니다.

## ✨ 주요 기능
자동 링크 탐지: https://로 시작하는 URL을 자동으로 감지
시각적 구분: 링크는 보라색 + 밑줄로 표시
외부 브라우저 연결: 링크 클릭 시 기본 브라우저에서 열림
보안 강화: HTTPS 링크만 허용 (HTTP 제외)

## 구현 내용
1. 링크 탐지 유틸리티 ( src/shared/utils/link-utils.ts)
2. 링크 렌더링 컴포넌트 ( src/shared/ui/linkified-text/index.tsx)
파싱된 텍스트를 받아 링크 부분은 TouchableOpacity로, 일반 텍스트는 Text로 렌더링
3. 적용 컴포넌트
 src/features/community/ui/article/index.tsx - 게시글 본문
 src/features/community/ui/comment/index.tsx - 댓글 내용
 src/features/community/ui/article-detail/article-detail.tsx - 게시글 상세 본문
 src/features/community/ui/article-detail/article-detail-comment.tsx - 상세 댓글
기존 Text 컴포넌트의 모든 props 지원

## 📱 테스트 방법
커뮤니티에서 게시글 작성 시 https://example.com 형태의 URL 입력
게시글/댓글에서 링크가 보라색 밑줄로 표시되는지 확인
링크 클릭 시 외부 브라우저에서 정상 열리는지 확인
HTTP 링크는 일반 텍스트로 표시되는지 확인