### PR TITLE
feat: 비로그인 유저가 커뮤니티에서 좋아요, 게시글 상세 조회 시도하면 랜딩페이지로 가도록 기능 추가

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "sometimes",
     "slug": "sometimes",
-    "version": "1.7.2",
+    "version": "1.7.3",
     "orientation": "portrait",
     "icon": "./assets/icons/app.png",
     "scheme": "myapp",

--- a/app/community/[id].tsx
+++ b/app/community/[id].tsx
@@ -9,7 +9,8 @@ import Loading from "@/src/features/loading";
 import { useBoolean } from "@/src/shared/hooks/use-boolean";
 import { Header, Show, Text } from "@/src/shared/ui";
 import { Dropdown, type DropdownItem } from "@/src/shared/ui/dropdown";
-import { Redirect, router, useLocalSearchParams } from "expo-router";
+import { router, useLocalSearchParams } from "expo-router";
+import { Linking } from "react-native";
 import type React from "react";
 import { useCallback, useMemo } from "react";
 import { KeyboardAvoidingView, Platform, Pressable, View } from "react-native";
@@ -58,6 +59,11 @@ export default function ArticleDetailScreen() {
     setFalse: closeDropdown,
   } = useBoolean();
   const { my } = useAuth();
+
+  if (!my?.id) {
+    Linking.openURL("https://info.some-in-univ.com");
+    return;
+  }
 
   const isValidArticle = (article: Article | undefined): article is Article => {
     return !!article && !!article.author;

--- a/src/features/community/ui/infinite-article-list.tsx
+++ b/src/features/community/ui/infinite-article-list.tsx
@@ -1,4 +1,5 @@
 import VectorIcon from "@/assets/icons/Vector.svg";
+import { useAuth } from "@/src/features/auth";
 import { useModal } from "@/src/shared/hooks/use-modal";
 import { tryCatch } from "@/src/shared/libs";
 import { Lottie, Text } from "@/src/shared/ui";
@@ -45,6 +46,7 @@ export const InfiniteArticleList = forwardRef<
 >(({ initialSize = 10 }: InfiniteArticleListProps, ref) => {
   const { showModal, showErrorModal } = useModal();
   const { currentCategory: categoryCode } = useCategory();
+  const { my } = useAuth();
   const flatListRef = useRef<FlatList<ArticleType>>(null) as RefObject<
     FlatList<ArticleType>
   >;
@@ -85,6 +87,11 @@ export const InfiniteArticleList = forwardRef<
   );
 
   const like = (item: ArticleType) => {
+    if (!my?.id) {
+      Linking.openURL("https://info.some-in-univ.com");
+      return;
+    }
+
     tryCatch(
       async () => {
         updateArticleLike(item.id);


### PR DESCRIPTION
## 📝 변경 사항
로그인하지 않은 사용자가 커뮤니티 기능을 사용하려고 할 때 서비스 랜딩 페이지로 리디렉션하도록 수정했습니다.
## 주요 수정 내용
+ 게시글 상세 페이지 접근 제한
로그인하지 않은 사용자가 게시글을 클릭하면 랜딩 페이지로 리디렉션
+ 좋아요 기능 접근 제한
커뮤니티 목록 페이지와 상세 페이지의 좋아요 버튼 클릭 시 랜딩 페이지로 리디렉션
## 🚀 동작 방식
Before (기존)
+ 로그인하지 않은 사용자도 커뮤니티 접근 가능
+ 좋아요/댓글 시도 시 401 에러 발생
+ 데이터베이스에 저장되지 않지만 푸시 알림은 전송됨(백엔드 푸시알림 수정으로 해당 문제는 해결됨)
After (수정 후)
+ 로그인하지 않은 사용자가 게시글 클릭 → https://info.some-in-univ.com 이동
+ 로그인하지 않은 사용자가 좋아요 클릭 → https://info.some-in-univ.com 이동
## 🧪 테스트 방법
+ 로그아웃 상태에서 커뮤니티 페이지 접근
+ 게시글 클릭 시 랜딩 페이지로 이동하는지 확인
+ 좋아요 버튼 클릭 시 랜딩 페이지로 이동하는지 확인
+ 로그인 상태에서는 기존 기능이 정상 작동하는지 확인
## 기대효과
비로그인 사용자에게 서비스 랜딩 페이지를 통한 자연스러운 가입 유도