### PR TITLE
Feat: 카카오 로그인 추적

### DIFF
--- a/src/features/pass/hooks/use-portone-login.ts
+++ b/src/features/pass/hooks/use-portone-login.ts
@@ -104,7 +104,7 @@ export const usePortOneLogin = ({
 					}
 				}
 
-				track('Signup_Route_Entered', { screen: 'AreaSelect' });
+				track('Signup_Route_Entered', { screen: 'AreaSelect', platform: 'pass' });
 				router.push({
 					pathname: '/auth/signup/area',
 					params: {
@@ -193,6 +193,7 @@ export const usePortOneLogin = ({
 
 			track('Signup_IdentityVerification_Started', {
 				platform: Platform.OS,
+				type: 'pass',
 			});
 
 			if (Platform.OS === 'web') {

--- a/src/features/signup/ui/kakao-login-web-view.tsx
+++ b/src/features/signup/ui/kakao-login-web-view.tsx
@@ -1,4 +1,5 @@
 import { useAuth } from "@/src/features/auth";
+import { track } from "@amplitude/analytics-react-native";
 import { useRouter } from "expo-router";
 // KakaoLoginWebView.tsx
 import type React from "react";
@@ -77,6 +78,10 @@ const KakaoLoginWebView: React.FC<KakaoLoginWebViewProps> = ({
     try {
       onClose();
       const result = await loginWithKakao(code);
+      track("Signup_Route_Entered", {
+        screen: "AreaSelect",
+        platform: "kakao",
+      });
 
       if (result.isNewUser) {
         router.push({


### PR DESCRIPTION
- 카카오 로그인 추적
- 기존 Signup_init과 Signup_route_entered 를 그대로 사용하고, 이벤트 프로퍼티(platform: kakao | pass) 로 구분