### PR TITLE
feat: 플랫폼별 업데이트 분기 처리

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "sometimes",
     "slug": "sometimes",
-    "version": "2.1.2",
+    "version": "2.1.3",
     "orientation": "portrait",
     "icon": "./assets/icons/app.png",
     "scheme": "myapp",

--- a/src/features/version-update/hooks/use-version-update.ts
+++ b/src/features/version-update/hooks/use-version-update.ts
@@ -1,10 +1,11 @@
 import {useState, useEffect, useCallback} from 'react';
 import {useLatestVersionQuery} from '../queries';
 import {compareVersions} from '@/src/shared/libs/version-utils';
-import {VersionUpdateResponse} from '../types';
+import {VersionSupportPlatform, VersionUpdateResponse} from '../types';
 import Constants from 'expo-constants';
 import * as Application from 'expo-application';
 import {useStorage} from '@/src/shared/hooks/use-storage';
+import { Platform } from 'react-native';
 
 const SKIPPED_VERSION_KEY = 'skipped_version';
 
@@ -25,8 +26,9 @@ export const useVersionUpdate = () => {
       return;
     }
     const needsUpdate = compareVersions(currentVersion, serverVersion);
+    const supportedPlatform = latestVersionData.metadata.supports.includes(Platform.OS as VersionSupportPlatform);
 
-    if (needsUpdate) {
+    if (needsUpdate && supportedPlatform) {
       setUpdateData(latestVersionData);
       setShowUpdateModal(true);
     }

--- a/src/features/version-update/types.ts
+++ b/src/features/version-update/types.ts
@@ -1,8 +1,11 @@
+export type VersionSupportPlatform = 'ios' | 'android' | 'web';
+
 export interface VersionUpdateResponse {
   id: string;
   version: string;
   metadata: {
     description: string[];
+    supports: VersionSupportPlatform[];
   };
   shouldUpdate: boolean;
 }


### PR DESCRIPTION
## Summary
- 앱스토어와 플레이스토어의 심사 주기 차이로 인한 플랫폼별 업데이트 분기 처리 기능 추가
- 서버에서 플랫폼별 업데이트 지원 정보를 포함한 버전 정보 제공
- 클라이언트에서 현재 플랫폼이 지원되는 경우에만 업데이트 알림 표시

## 주요 변경사항
- `VersionUpdateResponse` 타입에 `supports` 필드 추가 (지원 플랫폼 배열)
- `VersionSupportPlatform` 타입 추가 (`ios`, `android`, `web`)
- `useVersionUpdate` 훅에서 플랫폼별 업데이트 지원 여부 확인 로직 추가
- 앱 버전을 2.1.3으로 업데이트

## 배경
앱스토어와 플레이스토어의 심사 주기가 다르기 때문에, 한 플랫폼에서 업데이트가 승인되었지만 다른 플랫폼에서는 아직 심사 중인 상황이 발생합니다. 이로 인해 업데이트가 준비되지 않은 플랫폼 사용자에게도 업데이트 알림이 표시되는 문제가 있었습니다.

## 해결 방안
서버에서 각 버전별로 지원하는 플랫폼 정보(`supports` 배열)를 제공하고, 클라이언트에서는 현재 플랫폼이 해당 버전을 지원하는지 확인한 후에만 업데이트 알림을 표시하도록 개선했습니다.