### PR TITLE
chore: 배포 스크립트 활성화

### DIFF
--- a/.github/workflows/release-android.yml
+++ b/.github/workflows/release-android.yml
@@ -1,13 +1,15 @@
-name: Build and Submit iOS App
+name: Build and Submit Android App
+
 on:
   push:
     branches:
-      - main
+      - deploy/android
+      - deploy
 
 jobs:
-  build-and-submit-ios:
-    name: Build and Submit iOS
-    runs-on: macos-latest
+  build-and-submit-android:
+    name: Build and Submit Android
+    runs-on: ubuntu-latest
 
     steps:
       - name: ⬇️ Checkout repository
@@ -28,17 +30,14 @@ jobs:
       - name: 📦 Install dependencies
         run: npm install
 
-      - name: 🔑 Decode App Store Connect API Key
-        run: echo "${{ secrets.IOS_ENCODED_KEY }}" | base64 --decode >./AuthKey.p8
+      - name: 🔑 Decode Google Service Account Key
+        run: echo "${{ secrets.ANDROID_ENCODED_KEY }}" | base64 --decode >./google-service-account.json
 
-      - name: 🚀 Build iOS App
-        run: eas build --platform ios --profile production --non-interactive
+      - name: 🚀 Build Android App
+        run: eas build --platform android --profile production --non-interactive
 
-      - name: 📤 Submit to App Store
-        env:
-          ASC_API_KEY_ID: ${{ secrets.ASC_API_KEY_ID }}
-          ASC_API_ISSUER_ID: ${{ secrets.ASC_API_ISSUER_ID }}
-        run: eas submit --platform ios --profile production --latest --non-interactive
+      - name: 📤 Submit to Google Play Store
+        run: eas submit --platform android --profile production --latest --non-interactive
 
       - name: 📢 Notify Slack on Success
         if: success()
@@ -48,7 +47,7 @@ jobs:
           -H "Content-type: application/json" \
           --data '{
             "channel": "#썸타임-github-알림",
-            "text": ":white_check_mark: iOS 앱 빌드 및 배포가 완료되었습니다!",
+            "text": ":white_check_mark: Android 앱 빌드 및 배포가 완료되었습니다!",
             "username": "GitHub Bot",
             "attachments": [
               {
@@ -56,7 +55,7 @@ jobs:
                 "fields": [
                   {
                     "title": "플랫폼",
-                    "value": "iOS",
+                    "value": "Android",
                     "short": true
                   },
                   {
@@ -88,7 +87,7 @@ jobs:
           -H "Content-type: application/json" \
           --data '{
             "channel": "#썸타임-github-알림",
-            "text": ":x: iOS 앱 빌드 또는 배포에 실패했습니다.",
+            "text": ":x: Android 앱 빌드 또는 배포에 실패했습니다.",
             "username": "GitHub Bot",
             "attachments": [
               {
@@ -96,7 +95,7 @@ jobs:
                 "fields": [
                   {
                     "title": "플랫폼",
-                    "value": "iOS",
+                    "value": "Android",
                     "short": true
                   },
                   {

--- a/.github/workflows/release-ios.yml
+++ b/.github/workflows/release-ios.yml
@@ -1,14 +1,14 @@
-name: Build and Submit Android App
-
+name: Build and Submit iOS App
 on:
   push:
     branches:
-      - main
+      - deploy/ios
+      - deploy
 
 jobs:
-  build-and-submit-android:
-    name: Build and Submit Android
-    runs-on: ubuntu-latest
+  build-and-submit-ios:
+    name: Build and Submit iOS
+    runs-on: macos-latest
 
     steps:
       - name: ⬇️ Checkout repository
@@ -29,14 +29,17 @@ jobs:
       - name: 📦 Install dependencies
         run: npm install
 
-      - name: 🔑 Decode Google Service Account Key
-        run: echo "${{ secrets.ANDROID_ENCODED_KEY }}" | base64 --decode >./google-service-account.json
+      - name: 🔑 Decode App Store Connect API Key
+        run: echo "${{ secrets.IOS_ENCODED_KEY }}" | base64 --decode >./AuthKey.p8
 
-      - name: 🚀 Build Android App
-        run: eas build --platform android --profile production --non-interactive
+      - name: 🚀 Build iOS App
+        run: eas build --platform ios --profile production --non-interactive
 
-      - name: 📤 Submit to Google Play Store
-        run: eas submit --platform android --profile production --latest --non-interactive
+      - name: 📤 Submit to App Store
+        env:
+          ASC_API_KEY_ID: ${{ secrets.ASC_API_KEY_ID }}
+          ASC_API_ISSUER_ID: ${{ secrets.ASC_API_ISSUER_ID }}
+        run: eas submit --platform ios --profile production --latest --non-interactive
 
       - name: 📢 Notify Slack on Success
         if: success()
@@ -46,7 +49,7 @@ jobs:
           -H "Content-type: application/json" \
           --data '{
             "channel": "#썸타임-github-알림",
-            "text": ":white_check_mark: Android 앱 빌드 및 배포가 완료되었습니다!",
+            "text": ":white_check_mark: iOS 앱 빌드 및 배포가 완료되었습니다!",
             "username": "GitHub Bot",
             "attachments": [
               {
@@ -54,7 +57,7 @@ jobs:
                 "fields": [
                   {
                     "title": "플랫폼",
-                    "value": "Android",
+                    "value": "iOS",
                     "short": true
                   },
                   {
@@ -86,7 +89,7 @@ jobs:
           -H "Content-type: application/json" \
           --data '{
             "channel": "#썸타임-github-알림",
-            "text": ":x: Android 앱 빌드 또는 배포에 실패했습니다.",
+            "text": ":x: iOS 앱 빌드 또는 배포에 실패했습니다.",
             "username": "GitHub Bot",
             "attachments": [
               {
@@ -94,7 +97,7 @@ jobs:
                 "fields": [
                   {
                     "title": "플랫폼",
-                    "value": "Android",
+                    "value": "iOS",
                     "short": true
                   },
                   {

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "sometimes",
     "slug": "sometimes",
-    "version": "2.2.7",
+    "version": "2.2.8",
     "orientation": "portrait",
     "icon": "./assets/icons/app.png",
     "scheme": "myapp",


### PR DESCRIPTION
기존 `main` 에서 너무 빌드가 많이 발생하는 문제때문에 다음 키워드로 앱 자동 빌드를 관리합니다.

브랜치 기반으로 동작함

`deploy` - `AOS`, `iOS` 양쪽 모두 빌드
`deploy/android` - `AOS`빌드 수행
`deploy/ios`  -`iOS` 빌드 수행