### PR TITLE
fix: iOS에서 pass로그인 선택 시 뒤로가기 안되는 현상 수정

### DIFF
--- a/src/features/pass/ui/mobile-identity-verification.tsx
+++ b/src/features/pass/ui/mobile-identity-verification.tsx
@@ -3,12 +3,21 @@ import {
   type PortOneController,
 } from "@portone/react-native-sdk";
 import { useRef } from "react";
-import { Modal, StatusBar, View } from "react-native";
+import {
+  Modal,
+  StatusBar,
+  View,
+  TouchableOpacity,
+  Text as RNText,
+  StyleSheet,
+} from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
+import Feather from "@expo/vector-icons/Feather";
 import type {
   PortOneIdentityVerificationRequest,
   PortOneIdentityVerificationResponse,
 } from "../types";
+import { router } from "expo-router";
 
 interface MobileIdentityVerificationProps {
   request: PortOneIdentityVerificationRequest;
@@ -19,12 +28,14 @@ interface MobileIdentityVerificationProps {
 
 /**
  * 모바일에서 PortOne React Native SDK를 사용한 본인인증 컴포넌트
+ * 커스텀 Modal을 렌더링하며, 뒤로가기 기능을 포함합니다.
  */
 export const MobileIdentityVerification: React.FC<
   MobileIdentityVerificationProps
-> = ({ request, onComplete, onError }) => {
+> = ({ request, onComplete, onError, onCancel }) => {
   const controllerRef = useRef<PortOneController>(null);
   const insets = useSafeAreaInsets();
+
   const handleComplete = (response: unknown) => {
     if (!response) {
       onError?.(new Error("본인인증 응답이 없습니다."));
@@ -57,20 +68,32 @@ export const MobileIdentityVerification: React.FC<
     onError?.(new Error(errorMessage));
   };
 
+  const handleModalClose = () => {
+    onCancel?.();
+  };
+
   return (
     <Modal
       visible={true}
       animationType="slide"
       presentationStyle="fullScreen"
-      onRequestClose={() => {
-        // 안드로이드 뒤로가기 버튼 처리
-        onError?.(new Error("사용자가 인증을 취소했습니다."));
-      }}
+      onRequestClose={handleModalClose}
     >
       <StatusBar barStyle="dark-content" backgroundColor="white" />
       <View
         style={{ flex: 1, backgroundColor: "white", paddingTop: insets.top }}
       >
+        <View style={modalStyles.header}>
+          <TouchableOpacity
+            onPress={router.back}
+            style={modalStyles.backButton}
+          >
+            <Feather name="chevron-left" size={24} color="#000" />
+          </TouchableOpacity>
+          <RNText style={modalStyles.headerTitle}>본인 인증</RNText>
+          <View style={modalStyles.rightPlaceholder} />
+        </View>
+
         <IdentityVerification
           ref={controllerRef}
           request={request}
@@ -81,3 +104,28 @@ export const MobileIdentityVerification: React.FC<
     </Modal>
   );
 };
+
+const modalStyles = StyleSheet.create({
+  header: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingHorizontal: 16,
+    height: 56,
+    backgroundColor: "#FFFFFF",
+    borderBottomWidth: 1,
+    borderBottomColor: "#E7E9EC",
+  },
+  backButton: {
+    padding: 8,
+    marginLeft: -8,
+  },
+  headerTitle: {
+    fontSize: 17,
+    fontWeight: "600",
+    color: "#000",
+  },
+  rightPlaceholder: {
+    width: 24 + 16,
+  },
+});


### PR DESCRIPTION
- iOS에서 pass로그인 접속 시 초기 로그인 계정 선택 창으로 되돌아 갈 수 없는 현상을 수정.
- 그냥 모달로 하나더 감싸서 해결처리.