### PR TITLE
fix: 애플로그인 시작 및 완료 시 전역변수를 초기화하도록 수정

### DIFF
--- a/app/auth/login/apple-info.tsx
+++ b/app/auth/login/apple-info.tsx
@@ -1,3 +1,4 @@
+// UserInfoPage.tsx
 import { DefaultLayout } from "@/src/features/layout/ui";
 import Signup from "@/src/features/signup";
 import { Text } from "react-native";
@@ -19,6 +20,7 @@ import {
   SafeAreaView,
   useSafeAreaInsets,
 } from "react-native-safe-area-context";
+import { useStorage } from "@/src/shared/hooks/use-storage";
 
 const { useSignupProgress } = Signup;
 
@@ -26,6 +28,10 @@ export default function UserInfoPage() {
   const { updateForm, form } = useSignupProgress();
 
   const insets = useSafeAreaInsets();
+
+  const { value: appleUserFullName, loading: fullNameLoading } = useStorage<
+    string | null
+  >({ key: "appleUserFullName" });
 
   const [name, setName] = useState(form.name || "");
   const [gender, setGender] = useState(form.gender || null);
@@ -38,8 +44,16 @@ export default function UserInfoPage() {
   const dayRef = useRef<TextInput>(null);
   const phoneRef = useRef<TextInput>(null);
 
+  useEffect(() => {
+    if (appleUserFullName) {
+      setName(appleUserFullName);
+      updateForm({ name: appleUserFullName });
+    }
+  }, [appleUserFullName]);
+
+  // 이름이 useStorage 값으로 채워진 경우, 이름을 필수 입력 조건에서 제외.
   const isFormComplete =
-    !!name &&
+    (!!name || !!appleUserFullName) &&
     !!gender &&
     year.length === 4 &&
     month.length === 2 &&
@@ -121,6 +135,12 @@ export default function UserInfoPage() {
     }
   };
 
+  if (fullNameLoading) {
+    return null;
+  }
+
+  const shouldHideNameInput = !!appleUserFullName;
+
   return (
     <DefaultLayout>
       <View style={[styles.topBar, { paddingTop: insets.top }]}>
@@ -149,16 +169,18 @@ export default function UserInfoPage() {
           />
         </View>
 
-        <View style={styles.contentWrapper}>
-          <Text style={styles.title}>이름을 입력해주세요</Text>
-          <TextInput
-            style={styles.nameInput}
-            placeholder="구미호"
-            value={name}
-            onChangeText={setName}
-            maxLength={20}
-          />
-        </View>
+        {!shouldHideNameInput && (
+          <View style={styles.contentWrapper}>
+            <Text style={styles.title}>이름을 입력해주세요</Text>
+            <TextInput
+              style={styles.nameInput}
+              placeholder="구미호"
+              value={name}
+              onChangeText={setName}
+              maxLength={20}
+            />
+          </View>
+        )}
 
         <View style={styles.contentWrapper}>
           <Text style={styles.title}>성별을 선택해주세요</Text>
@@ -393,7 +415,6 @@ const styles = StyleSheet.create({
     paddingHorizontal: 20,
     backgroundColor: "#fff",
     alignItems: "center",
-    width: "100%",
   },
   messageContainer: {
     flexDirection: "row",

--- a/src/features/auth/hooks/use-auth.tsx
+++ b/src/features/auth/hooks/use-auth.tsx
@@ -1,4 +1,4 @@
-import { axiosClient, tryCatch } from "@/src/shared/libs";
+import { axiosClient, platform, tryCatch } from "@/src/shared/libs";
 import { eventBus } from "@/src/shared/libs/event-bus";
 import { registerForPushNotificationsAsync } from "@/src/shared/libs/notifications";
 import type { TokenResponse } from "@/src/types/auth";
@@ -8,7 +8,8 @@ import { useStorage } from "@shared/hooks/use-storage";
 import { router } from "expo-router";
 import { useEffect } from "react";
 import { useMyDetailsQuery, useProfileDetailsQuery } from "../queries";
-import {loginByPass} from "@features/auth/utils/login-utils";
+import { loginByPass } from "@features/auth/utils/login-utils";
+import { Platform } from "react-native";
 
 export function useAuth() {
   const { value: accessToken, setValue: setToken } = useStorage<string | null>({
@@ -30,6 +31,8 @@ export function useAuth() {
     key: "approval-status",
     initialValue: null,
   });
+
+  const { removeValue: removeAppleUserId } = useStorage({ key: "appleUserId" });
 
   const { data: profileDetails } = useProfileDetailsQuery(accessToken ?? null);
   const { my, ...myQueryProps } = useMyDetailsQuery(!!accessToken);
@@ -83,6 +86,13 @@ export function useAuth() {
       await setToken(null);
       await setRefreshToken(null);
       await setApprovalStatus(null);
+      if (Platform.OS === "ios") {
+        await removeAppleUserId();
+        console.log("iOS: appleUserId를 삭제합니다.");
+      } else {
+        sessionStorage.removeItem("appleUserId");
+        console.log("Web: appleUserId를 삭제합니다.");
+      }
       return;
     }
 

--- a/src/features/signup/hooks/use-signup-progress.tsx
+++ b/src/features/signup/hooks/use-signup-progress.tsx
@@ -14,6 +14,7 @@ export type SignupForm = {
   profileImages: string[];
   passVerified: boolean;
   kakaoId?: string;
+  appleId?: string;
 };
 
 type Agreement = {

--- a/src/features/signup/queries/use-apple-login.tsx
+++ b/src/features/signup/queries/use-apple-login.tsx
@@ -1,6 +1,9 @@
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { useRouter } from "expo-router";
 import apis from "../apis";
+import { useStorage } from "@/src/shared/hooks/use-storage";
+import { Platform } from "react-native";
+
 export interface AppleLoginResponse {
   accessToken: string;
   refreshToken: string;
@@ -8,6 +11,7 @@ export interface AppleLoginResponse {
   expiresIn: number;
   role: string;
   isNewUser: boolean;
+  appleId: string;
   certificationInfo: {
     externalId: string;
     provider: string;
@@ -15,12 +19,33 @@ export interface AppleLoginResponse {
 }
 export const useAppleLogin = () => {
   const router = useRouter();
+  const { setValue: setAppleUserId } = useStorage<string | null>({
+    key: "appleUserId",
+  });
+
   return useMutation({
     mutationFn: (identityToken: string) => {
       return apis.postAppleLogin(identityToken);
     },
     onSuccess: (result: AppleLoginResponse) => {
       if (result.isNewUser) {
+        if (Platform.OS === "ios") {
+          setAppleUserId(result.appleId);
+          console.log(
+            "iOS: appleId를 useStorage에 저장했습니다.",
+            result.appleId
+          );
+        } else if (Platform.OS === "web") {
+          if (typeof sessionStorage !== "undefined") {
+            sessionStorage.setItem("appleUserId", result.appleId);
+            console.log(
+              "Web: appleId를 localStorage에 직접 저장했습니다.",
+              result.appleId
+            );
+          } else {
+            console.warn("Web 환경이지만 localStorage에 저장하지 못했습니다.");
+          }
+        }
         router.replace({
           pathname: "/auth/login/apple-info",
           params: {


### PR DESCRIPTION
- 애플로그인 시 id정보를 서버에 전송하도록 수정합니다.
- 애플로그인 정보로 이름을 전역변수에 포함하면 추가정보 필드에서 이름을 받지 않도록 분기합니다(굳이? 애플이 시켜서 굳이.....).
- 애플로그인이 성공적으로 마무리되거나 애플로그인을 시도할 경우 web/ios환경에 따른 스토리지를 클린업합니다.