### PR TITLE
fix/mbti값 존재 여부에 따른 프로필 노출 해시태그 형식 수정

### DIFF
--- a/app/partner/view/[id].tsx
+++ b/app/partner/view/[id].tsx
@@ -191,8 +191,11 @@ export default function PartnerDetailScreen() {
               </Text>
               <View className="flex flex-row items-center">
                 <Text textColor="white" weight="light" size="sm">
-                  #{partner.mbti}
-                  &nbsp;#{partner.universityDetails?.name || ""}
+                  {partner.mbti
+                    ? `#${partner.mbti} #${
+                        partner.universityDetails?.name || ""
+                      }`
+                    : `#${partner.universityDetails?.name || ""}`}
                 </Text>
                 {/* &nbsp;<UniversityBadge authenticated={profile.authenticated} /> */}
               </View>


### PR DESCRIPTION
- mbti값 존재 여부에 따라 프로필 노출 해시태그의 형식을 수정합니다.
- mbti 값이 존재하지 않으면 학교에 대한 정보만 노출합니다.
- 이에 따른 '#'기호를 분기처리 합니다.