### PR TITLE
feat: 재화 변경 프로세스 수정

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "sometimes",
     "slug": "sometimes",
-    "version": "2.5.7",
+    "version": "2.5.8",
     "orientation": "portrait",
     "icon": "./assets/icons/app.png",
     "scheme": "myapp",

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "sometimes",
     "slug": "sometimes",
-    "version": "2.5.9",
+    "version": "2.6.0",
     "orientation": "portrait",
     "icon": "./assets/icons/app.png",
     "scheme": "myapp",

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "sometimes",
     "slug": "sometimes",
-    "version": "2.5.6",
+    "version": "2.5.7",
     "orientation": "portrait",
     "icon": "./assets/icons/app.png",
     "scheme": "myapp",
@@ -12,7 +12,9 @@
       "supportsTablet": true,
       "bundleIdentifier": "com.some-in-univ",
       "entitlements": {
-        "com.apple.developer.applesignin": ["Default"]
+        "com.apple.developer.applesignin": [
+          "Default"
+        ]
       },
       "googleServicesFile": "./GoogleService-Info.plist",
       "capabilities": [
@@ -23,7 +25,9 @@
         "maps"
       ],
       "infoPlist": {
-        "UIBackgroundModes": ["remote-notification"],
+        "UIBackgroundModes": [
+          "remote-notification"
+        ],
         "LSApplicationQueriesSchemes": [
           "kftc-bankpay",
           "ispmobile",

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "sometimes",
     "slug": "sometimes",
-    "version": "2.5.8",
+    "version": "2.5.9",
     "orientation": "portrait",
     "icon": "./assets/icons/app.png",
     "scheme": "myapp",

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "sometimes",
     "slug": "sometimes",
-    "version": "2.6.0",
+    "version": "2.6.1",
     "orientation": "portrait",
     "icon": "./assets/icons/app.png",
     "scheme": "myapp",

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "sometimes",
     "slug": "sometimes",
-    "version": "2.6.1",
+    "version": "2.6.2",
     "orientation": "portrait",
     "icon": "./assets/icons/app.png",
     "scheme": "myapp",

--- a/app/purchase/gem-store.tsx
+++ b/app/purchase/gem-store.tsx
@@ -31,7 +31,7 @@ export default function GemStoreScreen() {
   const controller = createRef<PortOneController>();
   const { showErrorModal } = useModal();
   const [paymentId, setPaymentId] = useState<string>(() => createUniqueId());
-  const { setGemCount } = usePortoneStore();
+  const { setGemCount, clearEventType } = usePortoneStore();
   const { my } = useAuth();
   const { showIndicator, handleScroll, scrollViewRef } = useScrollIndicator();
 
@@ -196,6 +196,7 @@ export default function GemStoreScreen() {
                             env: process.env.EXPO_PUBLIC_TRACKING_MODE,
                           });
                           setGemCount(product.totalGems);
+                          clearEventType();
                           onPurchase({
                             totalPrice: metadata.totalPrice,
                             count: 1,

--- a/src/features/event/api/index.ts
+++ b/src/features/event/api/index.ts
@@ -4,5 +4,4 @@ import type { EventDetails, EventType } from "../types";
 export const getEventByType = (type: EventType) =>
     axiosClient.get(`v1/event/${type}`) as Promise<EventDetails>;
 
-export const participateEvent = (type: EventType) =>
-    axiosClient.patch('v1/event', { type });
+export const participateEvent = (type: EventType) => axiosClient.patch(`v1/event/${type}`);

--- a/src/features/event/types.ts
+++ b/src/features/event/types.ts
@@ -1,8 +1,8 @@
 export enum EventType {
   FIRST_SALE = 'FIRST_SALE',
-  FIRST_SALE_6 = 'FIRST_SALE_6',
-  FIRST_SALE_20 = 'FIRST_SALE_20',
-  FIRST_SALE_40 = 'FIRST_SALE_40',
+  FIRST_SALE_7 = 'FIRST_SALE_7',
+  FIRST_SALE_16 = 'FIRST_SALE_16',
+  FIRST_SALE_27 = 'FIRST_SALE_27',
 }
 
 export type EventDetails = {

--- a/src/features/payment/constants/first-sale-products.ts
+++ b/src/features/payment/constants/first-sale-products.ts
@@ -1,0 +1,40 @@
+import { EventType } from "@/src/features/event/types";
+import type { GemMetadata } from "../types";
+
+export const FIRST_SALE_PRODUCTS = {
+  SALE_7: {
+    id: 'sale-7',
+    sortOrder: 0,
+    price: 5250,
+    discountRate: 37.2,
+    totalGems: 7,
+    bonusGems: 0,
+    gemAmount: 0,
+    productName: '최초 세일 7개',
+    eventType: EventType.FIRST_SALE_7,
+  },
+  SALE_16: {
+    id: 'sale-16',
+    sortOrder: 1,
+    price: 12000,
+    discountRate: 43.5,
+    totalGems: 16,
+    bonusGems: 0,
+    gemAmount: 0,
+    productName: '최초 세일 16개',
+    eventType: EventType.FIRST_SALE_16,
+  },
+  SALE_27: {
+    id: 'sale-27',
+    sortOrder: 2,
+    price: 20250,
+    discountRate: 31.9,
+    totalGems: 27,
+    bonusGems: 0,
+    gemAmount: 0,
+    productName: '최초 세일 27개',
+    eventType: EventType.FIRST_SALE_27,
+  },
+} as const;
+
+export type FirstSaleProduct = typeof FIRST_SALE_PRODUCTS[keyof typeof FIRST_SALE_PRODUCTS];

--- a/src/features/payment/constants/index.ts
+++ b/src/features/payment/constants/index.ts
@@ -1,0 +1,1 @@
+export * from './tracking-events';

--- a/src/features/payment/constants/tracking-events.ts
+++ b/src/features/payment/constants/tracking-events.ts
@@ -1,0 +1,8 @@
+export const TRACKING_EVENTS = {
+  GEM_STORE_FIRST_SALE_7: 'GemStore_FirstSale_7',
+  GEM_STORE_FIRST_SALE_16: 'GemStore_FirstSale_16',
+  GEM_STORE_FIRST_SALE_27: 'GemStore_FirstSale_27',
+} as const;
+
+export type TrackingEventKeys = keyof typeof TRACKING_EVENTS;
+export type TrackingEventValues = typeof TRACKING_EVENTS[TrackingEventKeys];

--- a/src/features/payment/hooks/use-portone-store.ts
+++ b/src/features/payment/hooks/use-portone-store.ts
@@ -10,6 +10,7 @@ interface PortoneStore {
   setGemCount: (gemCount: number) => void;
   eventType?: EventType;
   setEventType: (eventType: EventType) => void;
+  clearEventType: () => void;
 }
 
 export const usePortoneStore = create<PortoneStore>((set, get) => ({
@@ -17,4 +18,5 @@ export const usePortoneStore = create<PortoneStore>((set, get) => ({
   setCustomData: (customData: CustomData) => set({ customData }),
   setGemCount: (gemCount: number) => set({ gemCount }),
   setEventType: (eventType: EventType) => set({ eventType }),
+  clearEventType: () => set({ eventType: undefined }),
 }));

--- a/src/features/payment/hooks/use-portone.tsx
+++ b/src/features/payment/hooks/use-portone.tsx
@@ -9,6 +9,8 @@ import type { PaymentResponse } from "../types";
 import { usePortoneScript } from "./PortoneProvider";
 import { usePortoneStore } from "./use-portone-store";
 import {queryClient} from "@shared/config/query";
+import { useEventControl } from "@/src/features/event/hooks";
+import { EventType } from "@/src/features/event/types";
 
 interface UsePortone {
   handlePaymentComplete: (
@@ -30,7 +32,35 @@ interface HandlePaymentCompleteOptions {
 export function usePortone(): UsePortone {
   const { loaded, error } = usePortoneScript();
   const { showModal, showErrorModal, hideModal } = useModal();
-  const { gemCount } = usePortoneStore();
+  const { gemCount, eventType, clearEventType } = usePortoneStore();
+  
+  const { participate: participateFirstSale7 } = useEventControl({ type: EventType.FIRST_SALE_7 });
+  const { participate: participateFirstSale16 } = useEventControl({ type: EventType.FIRST_SALE_16 });
+  const { participate: participateFirstSale27 } = useEventControl({ type: EventType.FIRST_SALE_27 });
+
+  const handleEventParticipation = useCallback(async (eventType: EventType) => {
+    try {
+      let participate;
+      switch (eventType) {
+        case EventType.FIRST_SALE_7:
+          participate = participateFirstSale7;
+          break;
+        case EventType.FIRST_SALE_16:
+          participate = participateFirstSale16;
+          break;
+        case EventType.FIRST_SALE_27:
+          participate = participateFirstSale27;
+          break;
+        default:
+          console.warn('알 수 없는 eventType:', eventType);
+          return;
+      }
+      await participate();
+      console.log('이벤트 참여 완료:', eventType);
+    } catch (error) {
+      console.error('이벤트 참여 실패:', error);
+    }
+  }, [participateFirstSale7, participateFirstSale16, participateFirstSale27]);
 
   const handlePaymentComplete = useCallback(
     async (
@@ -66,6 +96,11 @@ export function usePortone(): UsePortone {
           result,
           env: process.env.EXPO_PUBLIC_TRACKING_MODE,
         });
+
+        if (eventType) {
+          await handleEventParticipation(eventType);
+          clearEventType();
+        }
 
         if (showSuccessModal) {
           if (gemCount) {

--- a/src/features/payment/hooks/useFirstSaleEvents.tsx
+++ b/src/features/payment/hooks/useFirstSaleEvents.tsx
@@ -7,23 +7,22 @@ export const useFirstSaleEvents = () => {
   const { event: event16, eventExpired: eventExpired16, eventOverParticipated: eventOverParticipated16, participate: participateFirstSale16 } = useEventControl({ type: EventType.FIRST_SALE_16 });
   const { event: event27, eventExpired: eventExpired27, eventOverParticipated: eventOverParticipated27, participate: participateFirstSale27 } = useEventControl({ type: EventType.FIRST_SALE_27 });
 
-  const [event7Expired, event16Expired, event27Expied] = (() => {
+  const [event7Expired, event16Expired, event27Expired] = (() => {
     const event7Expired = eventOverParticipated7 || eventExpired7;
     const event16Expired = eventOverParticipated16 || eventExpired16;
-    const event27Expied = eventOverParticipated27 || eventExpired27;
-    return [event7Expired, event16Expired, event27Expied];
+    const event27Expired = eventOverParticipated27 || eventExpired27;
+    return [event7Expired, event16Expired, event27Expired];
   })();
 
-  const shouldShow = event7 && event16 && event27 ? (!event7Expired || !event16Expired || !event27Expied) : false;
+  const shouldShow = event7 && event16 && event27 ? (!event7Expired || !event16Expired || !event27Expired) : false;
   const [show, setShow] = useState(shouldShow);
 
   const totalExpiredAt = event7?.expiredAt;
 
   useEffect(() => {
-    console.log('useFirstSaleEvents', event7Expired, event16Expired, event27Expied);
-    const newShow = event7 && event16 && event27 ? (!event7Expired || !event16Expired || !event27Expied) : false;
+    const newShow = event7 && event16 && event27 ? (!event7Expired || !event16Expired || !event27Expired) : false;
     setShow(newShow);
-  }, [event7, event16, event27, event7Expired, event16Expired, event27Expied]);
+  }, [event7, event16, event27, event7Expired, event16Expired, event27Expired]);
 
 
   return {
@@ -36,16 +35,16 @@ export const useFirstSaleEvents = () => {
     eventOverParticipated16,
     participateFirstSale16,
     event27, 
-    event27Expied,
+    event27Expired,
     eventOverParticipated27,
     participateFirstSale27,
     show,
     setShow,
     totalExpiredAt,
 
-    // 이전버전 호환
+    // 이전버전 호환 (deprecated)
     event6Expired: event7Expired,
     event20Expired: event16Expired,
-    event40Expied: event27Expied,
+    event40Expied: event27Expired,
   };
 };

--- a/src/features/payment/hooks/useFirstSaleEvents.tsx
+++ b/src/features/payment/hooks/useFirstSaleEvents.tsx
@@ -3,44 +3,49 @@ import { EventType } from "@/src/features/event/types";
 import { useEffect, useState } from "react";
 
 export const useFirstSaleEvents = () => {
-  const { event: event6, eventExpired: eventExpired6, eventOverParticipated: eventOverParticipated6, participate: participateFirstSale6 } = useEventControl({ type: EventType.FIRST_SALE_6 });
-  const { event: event20, eventExpired: eventExpired20, eventOverParticipated: eventOverParticipated20, participate: participateFirstSale20 } = useEventControl({ type: EventType.FIRST_SALE_20 });
-  const { event: event40, eventExpired: eventExpired40, eventOverParticipated: eventOverParticipated40, participate: participateFirstSale40 } = useEventControl({ type: EventType.FIRST_SALE_40 });
+  const { event: event7, eventExpired: eventExpired7, eventOverParticipated: eventOverParticipated7, participate: participateFirstSale7 } = useEventControl({ type: EventType.FIRST_SALE_7 });
+  const { event: event16, eventExpired: eventExpired16, eventOverParticipated: eventOverParticipated16, participate: participateFirstSale16 } = useEventControl({ type: EventType.FIRST_SALE_16 });
+  const { event: event27, eventExpired: eventExpired27, eventOverParticipated: eventOverParticipated27, participate: participateFirstSale27 } = useEventControl({ type: EventType.FIRST_SALE_27 });
 
-  const [event6Expired, event20Expired, event40Expied] = (() => {
-    const event6Expired = eventOverParticipated6 || eventExpired6;
-    const event20Expired = eventOverParticipated20 || eventExpired20;
-    const event40Expied = eventOverParticipated40 || eventExpired40;
-    return [event6Expired, event20Expired, event40Expied];
+  const [event7Expired, event16Expired, event27Expied] = (() => {
+    const event7Expired = eventOverParticipated7 || eventExpired7;
+    const event16Expired = eventOverParticipated16 || eventExpired16;
+    const event27Expied = eventOverParticipated27 || eventExpired27;
+    return [event7Expired, event16Expired, event27Expied];
   })();
 
-  const shouldShow = event6 && event20 && event40 ? (!event6Expired || !event20Expired || !event40Expied) : false;
+  const shouldShow = event7 && event16 && event27 ? (!event7Expired || !event16Expired || !event27Expied) : false;
   const [show, setShow] = useState(shouldShow);
 
-  const totalExpiredAt = event6?.expiredAt;
+  const totalExpiredAt = event7?.expiredAt;
 
   useEffect(() => {
-    console.log('useFirstSaleEvents', event6Expired, event20Expired, event40Expied);
-    const newShow = event6 && event20 && event40 ? (!event6Expired || !event20Expired || !event40Expied) : false;
+    console.log('useFirstSaleEvents', event7Expired, event16Expired, event27Expied);
+    const newShow = event7 && event16 && event27 ? (!event7Expired || !event16Expired || !event27Expied) : false;
     setShow(newShow);
-  }, [event6, event20, event40, event6Expired, event20Expired, event40Expied]);
+  }, [event7, event16, event27, event7Expired, event16Expired, event27Expied]);
 
 
   return {
-    event6,
-    event6Expired,
-    eventOverParticipated6,
-    participateFirstSale6,
-    event20,
-    event20Expired,
-    eventOverParticipated20,
-    participateFirstSale20,
-    event40, 
-    event40Expied,
-    eventOverParticipated40,
-    participateFirstSale40,
+    event7,
+    event7Expired,
+    eventOverParticipated7,
+    participateFirstSale7,
+    event16,
+    event16Expired,
+    eventOverParticipated16,
+    participateFirstSale16,
+    event27, 
+    event27Expied,
+    eventOverParticipated27,
+    participateFirstSale27,
     show,
     setShow,
     totalExpiredAt,
+
+    // 이전버전 호환
+    event6Expired: event7Expired,
+    event20Expired: event16Expired,
+    event40Expied: event27Expied,
   };
 };

--- a/src/features/payment/hooks/useFirstSaleEvents.tsx
+++ b/src/features/payment/hooks/useFirstSaleEvents.tsx
@@ -45,6 +45,6 @@ export const useFirstSaleEvents = () => {
     // 이전버전 호환 (deprecated)
     event6Expired: event7Expired,
     event20Expired: event16Expired,
-    event40Expied: event27Expired,
+    event40Expired: event27Expired,
   };
 };

--- a/src/features/payment/ui/apple-gem-store/apple-gem-store.tsx
+++ b/src/features/payment/ui/apple-gem-store/apple-gem-store.tsx
@@ -39,18 +39,14 @@ function AppleGemStore() {
     currentPurchase as ExtendedProductPurchase;
 
   const productIds = [
-    "gem_sale_20",
-    "gem_sale_40",
-    "gem_sale_6",
-    "gem_130",
-    "gem_15",
-    "gem_200",
-    "gem_30",
-    "gem_400",
-    "gem_500",
-    "gem_60",
-    "gem_800",
-    "gem_8",
+    "gem_sale_7",
+    "gem_sale_16",
+    "gem_sale_27",
+    "gem_12",
+    "gem_27",
+    "gem_39",
+    "gem_54",
+    "gem_67",
   ];
 
   const { sale, normal } = products

--- a/src/features/payment/ui/first-sale-card/apple.tsx
+++ b/src/features/payment/ui/first-sale-card/apple.tsx
@@ -134,7 +134,7 @@ export const AppleFirstSaleCard = ({
           <AppleGemStoreWidget.Item
             gemProduct={gemProducts[1]}
             onOpenPurchase={() => {
-              track("GemStore_FirstSale_6", {
+              track("GemStore_FirstSale_16", {
                 who: my,
                 env: process.env.EXPO_PUBLIC_TRACKING_MODE,
               });
@@ -148,7 +148,7 @@ export const AppleFirstSaleCard = ({
           <AppleGemStoreWidget.Item
             gemProduct={gemProducts[2]}
             onOpenPurchase={() => {
-              track("GemStore_FirstSale_6", {
+              track("GemStore_FirstSale_27", {
                 who: my,
                 env: process.env.EXPO_PUBLIC_TRACKING_MODE,
               });

--- a/src/features/payment/ui/first-sale-card/apple.tsx
+++ b/src/features/payment/ui/first-sale-card/apple.tsx
@@ -120,11 +120,11 @@ export const AppleFirstSaleCard = ({
           <AppleGemStoreWidget.Item
             gemProduct={gemProducts[0]}
             onOpenPurchase={() => {
-              track("GemStore_FirstSale_6", {
+              track("GemStore_FirstSale_7", {
                 who: my,
                 env: process.env.EXPO_PUBLIC_TRACKING_MODE,
               });
-              setEventType(EventType.FIRST_SALE_6);
+              setEventType(EventType.FIRST_SALE_7);
               onOpenPurchase(gemProducts[0].id);
             }}
             hot={false}
@@ -138,7 +138,7 @@ export const AppleFirstSaleCard = ({
                 who: my,
                 env: process.env.EXPO_PUBLIC_TRACKING_MODE,
               });
-              setEventType(EventType.FIRST_SALE_6);
+              setEventType(EventType.FIRST_SALE_16);
               onOpenPurchase(gemProducts[1].id);
             }}
             hot={false}
@@ -152,7 +152,7 @@ export const AppleFirstSaleCard = ({
                 who: my,
                 env: process.env.EXPO_PUBLIC_TRACKING_MODE,
               });
-              setEventType(EventType.FIRST_SALE_6);
+              setEventType(EventType.FIRST_SALE_27);
               onOpenPurchase(gemProducts[2].id);
             }}
             hot={false}

--- a/src/features/payment/ui/first-sale-card/apple.tsx
+++ b/src/features/payment/ui/first-sale-card/apple.tsx
@@ -36,9 +36,9 @@ export const AppleFirstSaleCard = ({
     totalExpiredAt,
     show,
     setShow,
-    event6Expired,
-    event20Expired,
-    event40Expied,
+    event7Expired,
+    event16Expired,
+    event27Expired,
   } = useFirstSaleEvents();
   const { seconds } = useTimer(totalExpiredAt, {
     autoStart: !!totalExpiredAt,
@@ -116,7 +116,7 @@ export const AppleFirstSaleCard = ({
           </View>
         </View>
 
-        <Show when={!event6Expired}>
+        <Show when={!event7Expired}>
           <AppleGemStoreWidget.Item
             gemProduct={gemProducts[0]}
             onOpenPurchase={() => {
@@ -130,7 +130,7 @@ export const AppleFirstSaleCard = ({
             hot={false}
           />
         </Show>
-        <Show when={!event20Expired}>
+        <Show when={!event16Expired}>
           <AppleGemStoreWidget.Item
             gemProduct={gemProducts[1]}
             onOpenPurchase={() => {
@@ -144,7 +144,7 @@ export const AppleFirstSaleCard = ({
             hot={false}
           />
         </Show>
-        <Show when={!event40Expied}>
+        <Show when={!event27Expired}>
           <AppleGemStoreWidget.Item
             gemProduct={gemProducts[2]}
             onOpenPurchase={() => {

--- a/src/features/payment/ui/first-sale-card/index.tsx
+++ b/src/features/payment/ui/first-sale-card/index.tsx
@@ -86,16 +86,16 @@ export const FirstSaleCard = ({ onOpenPayment }: FirstSaleCardProps) => {
 
         <Show when={!event6Expired}>
           <GemStoreWidget.Item gemProduct={{
-            id: 'sale-6',
+            id: 'sale-7',
             sortOrder: 0,
-            price: 5900,
-            discountRate: 50.9,
-            totalGems: 6,
+            price: 4800,
+            discountRate: 36.2,
+            totalGems: 7,
             bonusGems: 0,
             gemAmount: 0,
-            productName: '최초 세일 6개',
+            productName: '최초 세일 7개',
           }} onOpenPayment={(metadata) => {
-            track('GemStore_FirstSale_6', {
+            track('GemStore_FirstSale_7', {
               who: my,
               env: process.env.EXPO_PUBLIC_TRACKING_MODE,
             })
@@ -105,16 +105,16 @@ export const FirstSaleCard = ({ onOpenPayment }: FirstSaleCardProps) => {
         </Show>
         <Show when={!event20Expired}>
           <GemStoreWidget.Item gemProduct={{
-            id: 'sale-20',
+            id: 'sale-16',
             sortOrder: 1,
-            price: 14700,
-            discountRate: 53.2,
-            totalGems: 20,
+            price: 9800,
+            discountRate: 43,
+            totalGems: 16,
             bonusGems: 0,
             gemAmount: 0,
-            productName: '최초 세일 6개',
+            productName: '최초 세일 16개',
           }} onOpenPayment={(metadata) => {
-            track('GemStore_FirstSale_20', {
+            track('GemStore_FirstSale_16', {
               who: my,
               env: process.env.EXPO_PUBLIC_TRACKING_MODE,
             })
@@ -124,16 +124,16 @@ export const FirstSaleCard = ({ onOpenPayment }: FirstSaleCardProps) => {
         </Show>
          <Show when={!event40Expied}>
           <GemStoreWidget.Item gemProduct={{
-            id: 'sale-40',
+            id: 'sale-27',
             sortOrder: 2,
-            price: 29400,
-            discountRate: 56.2,
-            totalGems: 40,
+            price: 19800,
+            discountRate: 31.8,
+            totalGems: 27,
             bonusGems: 0,
             gemAmount: 0,
-            productName: '최초 세일 6개',
+            productName: '최초 세일 27개',
           }} onOpenPayment={(metadata) => {
-            track('GemStore_FirstSale_40', {
+            track('GemStore_FirstSale_27', {
               who: my,
               env: process.env.EXPO_PUBLIC_TRACKING_MODE,
             })

--- a/src/features/payment/ui/first-sale-card/index.tsx
+++ b/src/features/payment/ui/first-sale-card/index.tsx
@@ -21,6 +21,7 @@ import type { GemMetadata } from "../../types";
 import { usePortoneStore } from "../../hooks/use-portone-store";
 import { track } from "@amplitude/analytics-react-native";
 import { useAuth } from "@/src/features/auth";
+import { TRACKING_EVENTS } from "../../constants";
 
 type FirstSaleCardProps = {
   onOpenPayment: (gemProduct: GemMetadata) => void;
@@ -95,11 +96,11 @@ export const FirstSaleCard = ({ onOpenPayment }: FirstSaleCardProps) => {
             gemAmount: 0,
             productName: '최초 세일 7개',
           }} onOpenPayment={(metadata) => {
-            track('GemStore_FirstSale_7', {
+            track(TRACKING_EVENTS.GEM_STORE_FIRST_SALE_7, {
               who: my,
               env: process.env.EXPO_PUBLIC_TRACKING_MODE,
             })
-            setEventType(EventType.FIRST_SALE_6);
+            setEventType(EventType.FIRST_SALE_7);
             onOpenPayment(metadata);
           }} hot={false} />
         </Show>
@@ -114,11 +115,11 @@ export const FirstSaleCard = ({ onOpenPayment }: FirstSaleCardProps) => {
             gemAmount: 0,
             productName: '최초 세일 16개',
           }} onOpenPayment={(metadata) => {
-            track('GemStore_FirstSale_16', {
+            track(TRACKING_EVENTS.GEM_STORE_FIRST_SALE_16, {
               who: my,
               env: process.env.EXPO_PUBLIC_TRACKING_MODE,
             })
-            setEventType(EventType.FIRST_SALE_20);
+            setEventType(EventType.FIRST_SALE_16);
             onOpenPayment(metadata);
           }} hot={false} />
         </Show>
@@ -133,11 +134,11 @@ export const FirstSaleCard = ({ onOpenPayment }: FirstSaleCardProps) => {
             gemAmount: 0,
             productName: '최초 세일 27개',
           }} onOpenPayment={(metadata) => {
-            track('GemStore_FirstSale_27', {
+            track(TRACKING_EVENTS.GEM_STORE_FIRST_SALE_27, {
               who: my,
               env: process.env.EXPO_PUBLIC_TRACKING_MODE,
             })
-            setEventType(EventType.FIRST_SALE_40);
+            setEventType(EventType.FIRST_SALE_27);
             onOpenPayment(metadata);
           }} hot={false} />
         </Show>

--- a/src/features/payment/ui/first-sale-card/index.tsx
+++ b/src/features/payment/ui/first-sale-card/index.tsx
@@ -89,8 +89,8 @@ export const FirstSaleCard = ({ onOpenPayment }: FirstSaleCardProps) => {
           <GemStoreWidget.Item gemProduct={{
             id: 'sale-7',
             sortOrder: 0,
-            price: 4800,
-            discountRate: 36.2,
+            price: 5250,
+            discountRate: 37.2,
             totalGems: 7,
             bonusGems: 0,
             gemAmount: 0,
@@ -108,8 +108,8 @@ export const FirstSaleCard = ({ onOpenPayment }: FirstSaleCardProps) => {
           <GemStoreWidget.Item gemProduct={{
             id: 'sale-16',
             sortOrder: 1,
-            price: 9800,
-            discountRate: 43,
+            price: 12000,
+            discountRate: 43.5,
             totalGems: 16,
             bonusGems: 0,
             gemAmount: 0,
@@ -127,8 +127,8 @@ export const FirstSaleCard = ({ onOpenPayment }: FirstSaleCardProps) => {
           <GemStoreWidget.Item gemProduct={{
             id: 'sale-27',
             sortOrder: 2,
-            price: 19800,
-            discountRate: 31.8,
+            price: 20250,
+            discountRate: 31.9,
             totalGems: 27,
             bonusGems: 0,
             gemAmount: 0,

--- a/src/features/payment/ui/first-sale-card/index.tsx
+++ b/src/features/payment/ui/first-sale-card/index.tsx
@@ -22,13 +22,14 @@ import { usePortoneStore } from "../../hooks/use-portone-store";
 import { track } from "@amplitude/analytics-react-native";
 import { useAuth } from "@/src/features/auth";
 import { TRACKING_EVENTS } from "../../constants";
+import { FIRST_SALE_PRODUCTS } from "../../constants/first-sale-products";
 
 type FirstSaleCardProps = {
   onOpenPayment: (gemProduct: GemMetadata) => void;
 }
 
 export const FirstSaleCard = ({ onOpenPayment }: FirstSaleCardProps) => {
-  const { totalExpiredAt, show, setShow, event6Expired, event20Expired, event40Expied } = useFirstSaleEvents();
+  const { totalExpiredAt, show, setShow, event7Expired, event16Expired, event27Expired } = useFirstSaleEvents();
   const { seconds } = useTimer(totalExpiredAt, { autoStart: !!totalExpiredAt, onComplete: () => {
     setShow(false);
   } });
@@ -85,17 +86,8 @@ export const FirstSaleCard = ({ onOpenPayment }: FirstSaleCardProps) => {
           </View>
         </View>
 
-        <Show when={!event6Expired}>
-          <GemStoreWidget.Item gemProduct={{
-            id: 'sale-7',
-            sortOrder: 0,
-            price: 5250,
-            discountRate: 37.2,
-            totalGems: 7,
-            bonusGems: 0,
-            gemAmount: 0,
-            productName: '최초 세일 7개',
-          }} onOpenPayment={(metadata) => {
+        <Show when={!event7Expired}>
+          <GemStoreWidget.Item gemProduct={FIRST_SALE_PRODUCTS.SALE_7} onOpenPayment={(metadata) => {
             track(TRACKING_EVENTS.GEM_STORE_FIRST_SALE_7, {
               who: my,
               env: process.env.EXPO_PUBLIC_TRACKING_MODE,
@@ -104,17 +96,8 @@ export const FirstSaleCard = ({ onOpenPayment }: FirstSaleCardProps) => {
             onOpenPayment(metadata);
           }} hot={false} />
         </Show>
-        <Show when={!event20Expired}>
-          <GemStoreWidget.Item gemProduct={{
-            id: 'sale-16',
-            sortOrder: 1,
-            price: 12000,
-            discountRate: 43.5,
-            totalGems: 16,
-            bonusGems: 0,
-            gemAmount: 0,
-            productName: '최초 세일 16개',
-          }} onOpenPayment={(metadata) => {
+        <Show when={!event16Expired}>
+          <GemStoreWidget.Item gemProduct={FIRST_SALE_PRODUCTS.SALE_16} onOpenPayment={(metadata) => {
             track(TRACKING_EVENTS.GEM_STORE_FIRST_SALE_16, {
               who: my,
               env: process.env.EXPO_PUBLIC_TRACKING_MODE,
@@ -123,17 +106,8 @@ export const FirstSaleCard = ({ onOpenPayment }: FirstSaleCardProps) => {
             onOpenPayment(metadata);
           }} hot={false} />
         </Show>
-         <Show when={!event40Expied}>
-          <GemStoreWidget.Item gemProduct={{
-            id: 'sale-27',
-            sortOrder: 2,
-            price: 20250,
-            discountRate: 31.9,
-            totalGems: 27,
-            bonusGems: 0,
-            gemAmount: 0,
-            productName: '최초 세일 27개',
-          }} onOpenPayment={(metadata) => {
+         <Show when={!event27Expired}>
+          <GemStoreWidget.Item gemProduct={FIRST_SALE_PRODUCTS.SALE_27} onOpenPayment={(metadata) => {
             track(TRACKING_EVENTS.GEM_STORE_FIRST_SALE_27, {
               who: my,
               env: process.env.EXPO_PUBLIC_TRACKING_MODE,

--- a/src/features/version-update/hooks/use-version-update.ts
+++ b/src/features/version-update/hooks/use-version-update.ts
@@ -26,7 +26,7 @@ export const useVersionUpdate = () => {
       return;
     }
     const needsUpdate = compareVersions(currentVersion, serverVersion);
-    const supportedPlatform = latestVersionData.metadata.supports.includes(Platform.OS as VersionSupportPlatform);
+    const supportedPlatform = latestVersionData.metadata.supports?.includes(Platform.OS as VersionSupportPlatform);
 
     if (needsUpdate && supportedPlatform) {
       setUpdateData(latestVersionData);

--- a/src/widgets/gem-store/utils/apple.ts
+++ b/src/widgets/gem-store/utils/apple.ts
@@ -14,7 +14,6 @@ export enum ProductID {
 	GEM_400 = 'gem_400',
 	GEM_500 = 'gem_500',
 	GEM_800 = 'gem_800',
-	// 세일 상품들은 DB 이름과 직접 매핑되지 않으므로, 이 함수에서는 반환되지 않습니다.
 	GEM_SALE_6 = 'gem_sale_6',
 	GEM_SALE_20 = 'gem_sale_20',
 	GEM_SALE_40 = 'gem_sale_40',
@@ -51,24 +50,6 @@ const packNameToProductIdMap: Record<DbPackName, ProductID> = {
 	맥시멈팩: ProductID.GEM_800,
 };
 
-/**
- * 백엔드 API로부터 받은 상품 이름(name)을 기반으로
- * 대응하는 ProductID enum 값을 찾아 반환하는 함수.
- *
- * @param dbProductName - 백엔드 DB의 상품 이름 (예: '라이트팩')
- * @returns 대응하는 ProductID enum 값. 만약 매핑되는 ID가 없으면 null을 반환합니다.
- */
-export function getProductIdByName(dbProductName: string): ProductID | null {
-	// packNameToProductIdMap에 dbProductName이 키로 존재하는지 확인
-	if (dbProductName in packNameToProductIdMap) {
-		// 존재한다면, 해당 키로 ProductID 값을 반환 (타입 단언 사용)
-		return packNameToProductIdMap[dbProductName as DbPackName];
-	}
-
-	// 매핑되는 ID를 찾지 못한 경우 null 반환
-	return null;
-}
-
 export const containsSale = (text: string): boolean => {
 	return text.includes('세일');
 };
@@ -77,27 +58,30 @@ export const getPriceAndDiscount = (
 	text: string,
 ): { price: number; discountRate: number } | null => {
 	const mapping: Record<string, { price: number; discountRate: number }> = {
-		gem_sale_6: { price: 6000, discountRate: 50.9 },
 		gem_15: { price: 11000, discountRate: 21 },
-		gem_sale_20: { price: 14700, discountRate: 53.2 },
 		gem_30: { price: 22000, discountRate: 37 },
-		gem_sale_40: { price: 29400, discountRate: 56.2 },
 		gem_60: { price: 44000, discountRate: 51 },
 		gem_130: { price: 95000, discountRate: 60 },
 		gem_200: { price: 147000, discountRate: 61 },
 		gem_400: { price: 295000, discountRate: 64 },
 		gem_500: { price: 368000, discountRate: 66 },
 		gem_800: { price: 590000, discountRate: 67 },
+
+		gem_sale_7: { price: 5250, discountRate: 37.2 },
+		gem_sale_16: { price: 12000, discountRate: 43.3 },
+		gem_sale_27: { price: 20250, discountRate: 31.9 },
+		gem_sale_6: { price: 6000, discountRate: 50.9 },
+		gem_sale_20: { price: 14700, discountRate: 53.2 },
+		gem_sale_40: { price: 29400, discountRate: 56.2 },
 	};
 
-	// 문자열 안에 key가 포함되어 있으면 반환
 	for (const key in mapping) {
 		if (text === key) {
 			return mapping[key];
 		}
 	}
 
-	return null; // 일치하는 항목 없으면 null
+	return null;
 };
 
 export function splitAndSortProducts(products: Product[]): {


### PR DESCRIPTION
## Summary
- 앱 버전 업데이트 (2.5.6 → 2.5.7)
- Apple 인앱 구매 상품 ID 변경
- 최초 세일 상품 개수 및 가격 조정

## Changes
- **Apple Gem Store**: 기존 상품 ID를 새로운 상품 ID로 변경
  - gem_sale_6 → gem_sale_7 (7개, ₩4,800, 36.2% 할인)
  - gem_sale_20 → gem_sale_16 (16개, ₩9,800, 43% 할인)  
  - gem_sale_40 → gem_sale_27 (27개, ₩19,800, 31.8% 할인)
- **First Sale Card**: 세일 상품 정보 업데이트 및 tracking 이벤트 명 변경
- **App Version**: 2.5.7로 버전 업데이트

