### PR TITLE
hotfix: 커뮤니티에서 데이터를 한번에 불러오는 현상 수정

### DIFF
--- a/src/shared/infinite-scroll/custom-infinite-scroll-view.tsx
+++ b/src/shared/infinite-scroll/custom-infinite-scroll-view.tsx
@@ -1,4 +1,4 @@
-import { useCallback, type RefObject } from "react";
+import { useCallback, type RefObject, useEffect, useRef } from "react";
 import {
   ActivityIndicator,
   FlatList,
@@ -13,6 +13,7 @@ import { useInfiniteScroll } from "../hooks/use-infinite-scroll";
 interface CustomInfiniteScrollViewProps<T> extends InfiniteScrollViewProps<T> {
   flatListRef?: RefObject<FlatList<T>>;
   getItemKey?: (item: T, index: number) => string;
+  autoFillMaxPages?: number;
 }
 
 export function CustomInfiniteScrollView<T>({
@@ -30,15 +31,41 @@ export function CustomInfiniteScrollView<T>({
   threshold = 0.5,
   flatListRef,
   getItemKey,
+  autoFillMaxPages = 1,
   ...restProps
 }: CustomInfiniteScrollViewProps<T>) {
-  const { scrollProps, getLastItemProps, ensureFillTriggersLoad } =
-    useInfiniteScroll<T>(onLoadMore, {
-      threshold,
-      enabled: hasMore && !isLoadingMore,
+  const { scrollProps, getLastItemProps } = useInfiniteScroll<T>(onLoadMore, {
+    threshold,
+    enabled: hasMore && !isLoadingMore,
+  });
+
+  const autoFillCountRef = useRef(0);
+  useEffect(() => {
+    if (Platform.OS !== "web") return;
+    if (autoFillMaxPages <= 0) return;
+    if (!hasMore || isLoadingMore) return;
+    if (autoFillCountRef.current >= autoFillMaxPages) return;
+
+    const rAF = requestAnimationFrame(() => {
+      const doc = document.documentElement;
+      const body = document.body;
+      const scrollHeight = Math.max(
+        body.scrollHeight,
+        body.offsetHeight,
+        doc.clientHeight,
+        doc.scrollHeight,
+        doc.offsetHeight
+      );
+      const viewport = window.innerHeight || doc.clientHeight;
+
+      if (scrollHeight <= viewport + 4) {
+        autoFillCountRef.current += 1;
+        onLoadMore();
+      }
     });
 
-  ensureFillTriggersLoad?.(data, hasMore, isLoadingMore);
+    return () => cancelAnimationFrame(rAF);
+  }, [data.length, hasMore, isLoadingMore, onLoadMore, autoFillMaxPages]);
 
   const renderItemInternal = useCallback(
     ({ item, index }: { item: T; index: number }) => renderItem(item, index),


### PR DESCRIPTION
ㅈ됐다.....!
비이성적으로 데이터를 다 불러오는 현상 수정
현재 다음 페이지를 잘 못불러오는 것으로 확인 됨 