### PR TITLE
fix/커뮤니티 무한스크롤 페이지 로딩 실패 수정

### DIFF
--- a/app/community/index.tsx
+++ b/app/community/index.tsx
@@ -14,27 +14,21 @@ export default function CommunityScreen() {
   const { refresh: shouldRefresh } = useLocalSearchParams<{
     refresh: string;
   }>();
-  const {
-    currentCategory: categoryCode,
-  } = useCategory();
+  const { currentCategory: categoryCode } = useCategory();
   const queryClient = useQueryClient();
 
   useEffect(() => {
+    if (!categoryCode) return;
     prefetchArticlesFirstPage(queryClient, categoryCode, 10).catch(() => {});
   }, [categoryCode, queryClient]);
 
   const { refetch } = useInfiniteArticlesQuery({ categoryCode, pageSize: 10 });
+
   useEffect(() => {
     if (shouldRefresh === "true") {
       refetch();
     }
   }, [shouldRefresh, refetch]);
-
-
-
-
-
-
 
   return (
     <View className="flex-1 relative">
@@ -43,7 +37,7 @@ export default function CommunityScreen() {
       <View className="flex-1 bg-white">
         <View style={{ height: 1, backgroundColor: "#F3F0FF" }} />
         <InfiniteArticleList
-          key={`list-${categoryCode}`}
+          key={`list-${categoryCode ?? "none"}`}
           initialSize={10}
           categoryCode={categoryCode}
           preferSkeletonOnCategoryChange


### PR DESCRIPTION
- 커뮤니티 게시글 로딩시 모든 게시글을 로딩하는 버그가 있어 해결했으나 다음 페이지 로딩이 실패하는 현상이 발생.
- 하단 옵저버/풀백 기반 로딩 로직에서 페이지 경계 진입 시 프리패치하도록 로직을 수정합니다.
- 각 페이지 진입마다 다음 페이지를 패치합니다.