### PR TITLE
fiix: 푸시알림 딥링크 콜드스타트 오류 수정

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "sometimes",
     "slug": "sometimes",
-    "version": "2.7.3",
+    "version": "2.7.4",
     "orientation": "portrait",
     "icon": "./assets/icons/app.png",
     "scheme": "myapp",

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "sometimes",
     "slug": "sometimes",
-    "version": "2.7.2",
+    "version": "2.7.3",
     "orientation": "portrait",
     "icon": "./assets/icons/app.png",
     "scheme": "myapp",

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "sometimes",
     "slug": "sometimes",
-    "version": "2.7.1",
+    "version": "2.7.2",
     "orientation": "portrait",
     "icon": "./assets/icons/app.png",
     "scheme": "myapp",

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -8,7 +8,6 @@ import "../global.css";
 import {
   type NotificationData,
   handleNotificationTap,
-  registerForPushNotificationsAsync,
 } from "@/src/shared/libs/notifications";
 import * as Notifications from "expo-notifications";
 
@@ -69,22 +68,7 @@ export default function RootLayout() {
     []
   );
 
-  useEffect(() => {
-    if (!loaded) return;
 
-    const initializePushNotifications = async () => {
-      try {
-        const token = await registerForPushNotificationsAsync();
-        if (token) {
-          console.log('푸시 토큰 등록 완료:', token);
-        }
-      } catch (error) {
-        console.error('푸시알림 초기화 오류:', error);
-      }
-    };
-
-    initializePushNotifications();
-  }, [loaded]);
 
   useEffect(() => {
     if (!loaded) return;

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -74,7 +74,7 @@ export default function RootLayout() {
   useEffect(() => {
     if (!loaded) return;
 
-    const handleColdStartNotification = async () => {
+    const handleColdStartNotification = () => {
       try {
         const lastNotificationResponse = Notifications.getLastNotificationResponse();
 


### PR DESCRIPTION
## 문제 상황
앱이 백그라운드에서 실행되지 않을 때(콜드스타트) 푸시알림을 탭해도 딥링크가 동작하지 않는 문제 발생

## 해결 방법
Notifications.getLastNotificationResponse()를 사용하여 콜드스타트 시 마지막 알림 응답을 확인하고 딥링크를 처리하도록 구현했습니다.

## 주요 변경사항
콜드스타트 알림 처리 로직 추가 (app/_layout.tsx)
앱 로드 완료 후 마지막 알림 응답 확인
유효한 알림 데이터인 경우 딥링크 처리

## 테스트
콜드스타트 테스트: 앱을 완전히 종료한 상태에서 푸시알림 탭 시 올바른 페이지로 이동하는지 확인
백그라운드 테스트: 앱이 백그라운드에 있을 때 푸시알림 탭 시 정상 동작하는지 확인
포그라운드 테스트: 앱이 활성 상태일 때 푸시알림 처리가 정상적으로 동작하는지 확인