### PR TITLE
fix: admin계정에서 공지글 작성 FAB가 비활성화 되는 오류 수정

### DIFF
--- a/src/features/auth/apis/index.tsx
+++ b/src/features/auth/apis/index.tsx
@@ -2,10 +2,17 @@ import type { PassLoginResponse } from "@/src/auth/dto/pass-login.dto";
 import { axiosClient } from "@shared/libs";
 // @ts-ignore
 import type { MyDetails } from "@types/user";
+type MySimpleDetails = {
+  role: "admin" | "user";
+  id: string;
+  profileId: string;
+  name: string;
+};
 
 export { appleReviewLogin } from "./apple-review-login";
 
-export const getMySimpleDetails = () => axiosClient.get("/user");
+export const getMySimpleDetails = (): Promise<MySimpleDetails> =>
+  axiosClient.get("/user");
 
 export const checkExistsInstagram = (
   instagramId: string

--- a/src/features/community/ui/create-article-fab.tsx
+++ b/src/features/community/ui/create-article-fab.tsx
@@ -8,7 +8,7 @@ import { useQuery } from "@tanstack/react-query";
 import { getMySimpleDetails } from "@/src/features/auth/apis";
 
 type MySimpleDetails = {
-  role: string; // 'admin' | 'user'?? 서버 회원 구분을 잘 모르겠다.... 파악되면 그때 정의
+  role: "admin" | "user";
   id: string;
   profileId: string;
   name: string;
@@ -29,7 +29,7 @@ export const CreateArticleFAB = () => {
 
   const { data: me } = useQuery<MySimpleDetails>({
     queryKey: ["my-simple-details"],
-    queryFn: async () => (await getMySimpleDetails()).data,
+    queryFn: async () => await getMySimpleDetails(),
     enabled: !!profileDetails,
     staleTime: 5 * 60 * 1000,
   });


### PR DESCRIPTION
- 관리자 계정임에도 커뮤니티 공지 탭에서 공지글 작성 플로팅 액션 버튼이 노출되지 않는 문제가 있었습니다.
- 타입스크립트가 데이터 구조 파악을 못하는 것으로 파악(내가 파악한건 아니고 건상님이 도와주셔서ㅎㅎㅎㅎㅎㅎ).
- 타입을 정의해 해당 문제를 해결하여 FAB가 계정 유형에 따라 올바르게 노출됩니다.