### PR TITLE
feat: post-box 및 채팅방에서 프로필 상세 조회 기능 추가

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "sometimes",
     "slug": "sometimes",
-    "version": "2.8.1",
+    "version": "2.8.2",
     "orientation": "portrait",
     "icon": "./assets/icons/app.png",
     "scheme": "myapp",

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "sometimes",
     "slug": "sometimes",
-    "version": "2.7.9",
+    "version": "2.8.0",
     "orientation": "portrait",
     "icon": "./assets/icons/app.png",
     "scheme": "myapp",

--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "sometimes",
     "slug": "sometimes",
-    "version": "2.8.0",
+    "version": "2.8.1",
     "orientation": "portrait",
     "icon": "./assets/icons/app.png",
     "scheme": "myapp",

--- a/src/features/chat/types/chat.ts
+++ b/src/features/chat/types/chat.ts
@@ -18,6 +18,7 @@ export interface Chat {
 }
 
 export interface ChatRoomDetail {
+	matchId: string;
 	partnerId: string;
 	roomActivation: boolean;
 	createdAt: string;

--- a/src/features/chat/ui/chat-list.tsx
+++ b/src/features/chat/ui/chat-list.tsx
@@ -55,7 +55,6 @@ const ChatList = ({ setPhotoClicked }: ChatListProps) => {
 
   const formattedChatList = chatList.map((chat) => {
     const date = new Date(chat.createdAt);
-    date.setHours(date.getHours() - 9);
     const year = date.getFullYear();
     const month = String(date.getMonth() + 1).padStart(2, "0");
     const day = String(date.getDate()).padStart(2, "0");

--- a/src/features/chat/ui/chat-room-header.tsx
+++ b/src/features/chat/ui/chat-room-header.tsx
@@ -15,6 +15,14 @@ function ChatRoomHeader() {
   const handleClose = useCallback(() => {
     setVisible(false);
   }, []);
+
+  const handleProfilePress = () => {
+    if (!partner) return;
+    const isExpired = !(partner.roomActivation || partner.hasLeft);
+    if (isExpired) return;
+    router.push(`/partner/view/${partner.matchId}`);
+  };
+
   return (
     <>
       <ChatInfoModalContainer visible={isVisible} onClose={handleClose} />
@@ -22,17 +30,19 @@ function ChatRoomHeader() {
         <Pressable onPress={() => router.navigate("/chat")}>
           <ChevronLeft width={20} height={20} />
         </Pressable>
-        <Image
-          source={partner?.partner.mainProfileImageUrl ?? ""}
-          style={styles.profileImage}
-        />
-        <View style={styles.profileContainer}>
-          <Text style={styles.name}>{partner?.partner.name}</Text>
-          <View style={styles.schoolContainer}>
-            <Text style={styles.school}>{partner?.partner.university}</Text>
-            <Text style={styles.school}>{partner?.partner.department}</Text>
+        <Pressable onPress={handleProfilePress} style={styles.profilePressable}>
+          <Image
+            source={partner?.partner.mainProfileImageUrl ?? ""}
+            style={styles.profileImage}
+          />
+          <View style={styles.profileContainer}>
+            <Text style={styles.name}>{partner?.partner.name}</Text>
+            <View style={styles.schoolContainer}>
+              <Text style={styles.school}>{partner?.partner.university}</Text>
+              <Text style={styles.school}>{partner?.partner.department}</Text>
+            </View>
           </View>
-        </View>
+        </Pressable>
         <Pressable
           style={{
             width: 36,
@@ -57,6 +67,11 @@ const styles = StyleSheet.create({
     flexDirection: "row",
     paddingHorizontal: 16,
     alignItems: "center",
+  },
+  profilePressable: {
+    flexDirection: "row",
+    alignItems: "center",
+    flex: 1,
   },
   profileImage: {
     width: 34,

--- a/src/features/payment/ui/gem-store/banner.tsx
+++ b/src/features/payment/ui/gem-store/banner.tsx
@@ -18,16 +18,6 @@ export const Banner = () => {
             resource={ImageResources.GEM_STORE_BANNER}
             style={{width: "100%", height}}
         />
-        <Pressable style={styles.guideButton} onPress={() => router.push('/community/01987e8f-7a3f-70c0-9489-d63922ed14aa')}>
-          <ImageResource
-            resource={ImageResources.TICKET}
-            width={36}
-            height={36}
-          />
-          <Text weight="bold" textColor="black" size="12">
-            기존 재매칭권은 어떻게 되나요?
-          </Text>
-        </Pressable>
       </View>
   );
 };


### PR DESCRIPTION
# Pull Request

## Summary
post-box와 채팅방 상세에서 상대방 프로필 터치 시 프로필 상세 화면으로 이동하는 기능 추가. 만료되거나 탈퇴한 경우 네비게이션 차단.

## Linked Issues
- N/A

## Changes
- **chat-room-header.tsx**: 채팅방 헤더 프로필 영역 터치 시 `/partner/view/${matchId}` 이동 추가
  - `roomActivation` 및 `hasLeft` 상태 기반 만료 체크
  - 만료 시 네비게이션 차단

## Screenshots / Recordings (if UI)
- N/A (네비게이션 기능)

## Testing Plan
- Manual checks:
  - [ ] post-box에서 정상 프로필 터치 → 프로필 상세 이동 확인
  - [ ] post-box에서 만료/탈퇴 프로필 터치 → 이동 안됨 확인
  - [ ] 채팅방 헤더에서 정상 프로필 터치 → 프로필 상세 이동 확인
  - [ ] 채팅방 헤더에서 만료/탈퇴 프로필 터치 → 이동 안됨 확인

## Breaking Changes
- 없음

## Release Notes
- post-box 및 채팅방에서 상대방 프로필 터치 시 프로필 상세 화면 이동 가능